### PR TITLE
Add Input Number, make editing values generic

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -47,7 +47,6 @@ external_components:
       homeassistant_component, # base component to control home assistant entities. required for all
       homeassistant_switch_group, # only include if you use switches in menu
       homeassistant_sensor_group, # only include if you use text sensors in menu
-      homeassistant_light_group, # only include if you use lights in menu
       homeassistant_media_player, # only include if you use media players in menu
       homeassistant_service_group, # only include if you want to call services/scripts
       media_player_source, # required for all media player sources
@@ -94,12 +93,6 @@ text_sensor:
     name: "Weather"
     id: sensor_weather
 
-light:
-  - platform: homeassistant_light_group
-    id: light_office_lamp
-    entity_id: light.office_lamp
-    name: Office Lamp
-
 # sonos favorite source
 media_player_source_sonos:
   id: sonos
@@ -135,12 +128,6 @@ homeassistant_sensor_group:
   id: sensor_group_component
   sensors:
     - id: sensor_weather
-
-# light menu - replace with your IDs
-homeassistant_light_group:
-  id: light_group_component
-  lights:
-    - id: light_office_lamp
 
 # media player menu - replace with your IDs
 homeassistant_media_player:
@@ -179,7 +166,6 @@ homeThing:
     charging: charging
    # need atleast 1 group_component
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/MenuOptions.md
+++ b/MenuOptions.md
@@ -13,7 +13,6 @@ homeThing:
     battery_percent: battery_percent
     charging: connected
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/common/device_base.yaml
+++ b/common/device_base.yaml
@@ -40,3 +40,29 @@ sensor:
     unit_of_measurement: 'B'
     state_class: measurement
     update_interval: 10s
+  - platform: wifi_signal # Reports the WiFi signal strength/RSSI in dB
+    name: "WiFi Signal dB"
+    id: wifi_signal_db
+    update_interval: 60s
+    entity_category: "diagnostic"
+    internal: True
+  - platform: copy # Reports the WiFi signal strength in %
+    source_id: wifi_signal_db
+    name: "WiFi Signal %"
+    id: wifi_signal_percent
+    internal: True
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "Signal %"
+    entity_category: "diagnostic"
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: IP Address
+      internal: True
+      id: wifi_ip
+    ssid:
+      name: SSID
+      internal: True
+      id: wifi_ssid

--- a/components/homeThing/__init__.py
+++ b/components/homeThing/__init__.py
@@ -5,8 +5,7 @@ from esphome.components import display, font, color, wifi, api, binary_sensor, s
 from esphome.components.light import LightState
 from esphome.const import  CONF_ID, CONF_TRIGGER_ID, CONF_MODE, CONF_RED, CONF_BLUE, CONF_GREEN, CONF_NAME, CONF_TYPE
 from esphome.components.homeassistant_media_player import homeassistant_media_player_ns
-from esphome.components.homeassistant_light_group import homeassistant_light_group_ns
-from esphome.components.homeassistant_service_group import homeassistant_service_group_ns, SERVICE_LIST_SCHEMA
+from esphome.components.homeassistant_service_group import homeassistant_service_group_ns
 from esphome.components.homeassistant_sensor_group import homeassistant_sensor_group_ns
 from esphome.components.homeassistant_switch_group import homeassistant_switch_group_ns
 homething_menu_base_ns = cg.esphome_ns.namespace("homething_menu_base")
@@ -41,7 +40,6 @@ CONF_API = "api_connected"
 CONF_BOOT = "boot"
 CONF_HEADER = "header"
 CONF_MEDIA_PLAYERS = "media_player_group"
-CONF_LIGHT_GROUP = "light_group"
 CONF_SERVICE_GROUP = "service_group"
 CONF_SENSOR_GROUP = "sensor_group"
 CONF_SWITCH_GROUP = "switch_group"
@@ -311,10 +309,9 @@ CONFIG_SCHEMA =  cv.All(
             cv.Optional(CONF_HEADER, default={}): HEADER_SCHEMA,
             cv.Optional(CONF_MENU_DISPLAY, default={}): MENU_DISPLAY_SCHEMA,
             cv.Optional(CONF_MEDIA_PLAYERS): cv.use_id(homeassistant_media_player_ns.HomeAssistantMediaPlayerGroup),
-            cv.Optional(CONF_LIGHT_GROUP): cv.use_id(homeassistant_light_group_ns.HomeAssistantLightGroup),
-            cv.Optional(CONF_SERVICE_GROUP): cv.use_id(homeassistant_light_group_ns.HomeAssistantServiceGroup),
+            cv.Optional(CONF_SERVICE_GROUP): cv.use_id(homeassistant_service_group_ns.HomeAssistantServiceGroup),
             cv.Optional(CONF_SWITCH_GROUP): cv.use_id(homeassistant_switch_group_ns.HomeAssistantSwitchGroup),
-            cv.Optional(CONF_SENSOR_GROUP): cv.use_id(homeassistant_light_group_ns.HomeAssistantSensorsGroup),
+            cv.Optional(CONF_SENSOR_GROUP): cv.use_id(homeassistant_sensor_group_ns.HomeAssistantSensorsGroup),
             cv.Optional(CONF_BOOT, default={}): BOOT_SCHEMA,
             cv.Optional(CONF_ON_REDRAW): automation.validate_automation(
                 {
@@ -328,7 +325,7 @@ CONFIG_SCHEMA =  cv.All(
             ),
         }
     ).extend(cv.polling_component_schema("1s")),
-    cv.has_at_least_one_key(CONF_MEDIA_PLAYERS,  CONF_LIGHT_GROUP, CONF_SERVICE_GROUP, CONF_SWITCH_GROUP, CONF_SENSORS)
+    cv.has_at_least_one_key(CONF_MEDIA_PLAYERS, CONF_SERVICE_GROUP, CONF_SWITCH_GROUP, CONF_SENSORS, CONF_SCREENS)
 )
 
 async def ids_to_code(config, var, types):
@@ -428,10 +425,10 @@ NOW_PLAYING_IDS = [
     CONF_MEDIA_PLAYERS
 ]
 MENU_HEADER_IDS = [
-    CONF_MEDIA_PLAYERS, CONF_LIGHT_GROUP
+    CONF_MEDIA_PLAYERS
 ]
 MENU_DISPLAY_IDS = [
-    CONF_MEDIA_PLAYERS, CONF_LIGHT_GROUP
+    CONF_MEDIA_PLAYERS
 ]
 
 async def menu_display_to_code(config, display_buffer):
@@ -462,10 +459,6 @@ async def menu_screen_to_code(config):
         cg.add_define("SHOW_VERSION")
         cg.add(menu_screen.set_show_version(config[CONF_SHOW_VERSION]))
 
-    switch_added = False
-    text_sensor_added = False
-    light_added = False
-    sensor_added = False
     for conf in config.get(CONF_ENTITIES, []):
         if conf[CONF_TYPE] == CONF_SWITCH:
             new_switch = await cg.get_variable(conf[CONF_ID])
@@ -497,7 +490,6 @@ MENU_IDS = [
     CONF_BACKLIGHT,
     CONF_SLEEP_SWITCH,
     CONF_MEDIA_PLAYERS,
-    CONF_LIGHT_GROUP, 
     CONF_SERVICE_GROUP, 
     CONF_SWITCHES, 
     CONF_SENSORS

--- a/components/homeThing/__init__.py
+++ b/components/homeThing/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import display, font, color, wifi, api, binary_sensor, sensor, switch, light, text_sensor, script
+from esphome.components import display, font, color, wifi, api, binary_sensor, sensor, switch, light, text_sensor, number
 from esphome.components.light import LightState
 from esphome.const import  CONF_ID, CONF_TRIGGER_ID, CONF_MODE, CONF_RED, CONF_BLUE, CONF_GREEN, CONF_NAME, CONF_TYPE
 from esphome.components.homeassistant_media_player import homeassistant_media_player_ns
@@ -59,6 +59,7 @@ CONF_LIGHT = "light"
 CONF_TEXT_SENSOR = "text_sensor"
 CONF_SWITCH = "switch"
 CONF_ENTITIES = "entities"
+CONF_NUMBER = "number"
 
 # battery settings
 CONF_CHARGING = "charging"
@@ -277,6 +278,11 @@ MENU_ENTITY_TYPED_SCHEMA = cv.typed_schema(
                 cv.GenerateID(CONF_ID): cv.use_id(sensor.Sensor)
             }
         ),
+        CONF_NUMBER: cv.Schema(
+            {
+                cv.GenerateID(CONF_ID): cv.use_id(number.Number)
+            }
+        ),
     },
     key=CONF_TYPE
 )
@@ -482,6 +488,9 @@ async def menu_screen_to_code(config):
         elif conf[CONF_TYPE] == CONF_SENSOR:
             new_sensor = await cg.get_variable(conf[CONF_ID])
             cg.add(menu_screen.register_sensor(new_sensor))
+        elif conf[CONF_TYPE] == CONF_NUMBER:
+            new_number = await cg.get_variable(conf[CONF_ID])
+            cg.add(menu_screen.register_number(new_number))
     return menu_screen
 
 MENU_IDS = [

--- a/components/homeThing/homeThingLightHelpers.h
+++ b/components/homeThing/homeThingLightHelpers.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "esphome/components/homeThing/homeThingMenuScreen.h"
+#include "esphome/components/light/light_state.h"
+#include "esphome/core/color.h"
+
+namespace esphome {
+namespace homething_menu_base {
+
+static const char* const LIGHT_HELPERS_TAG = "homething.light.helpers";
+class HomeThingLightHelpers {
+ public:
+  static void toggleLight(light::LightState* light) {
+    if (light) {
+      if (!light->remote_values.is_on() &&
+          light->remote_values.get_brightness() == 0) {
+        auto call = light->make_call();
+        call.set_state(true);
+        call.set_brightness(1.0);
+        auto traits = light->get_traits();
+        if (traits.supports_color_mode(light::ColorMode::RGB)) {
+          call.set_color_mode(light::ColorMode::RGB);
+          call.set_rgb(1, 1, 1);
+        } else if (traits.supports_color_mode(light::ColorMode::RGB_WHITE)) {
+          call.set_color_mode(light::ColorMode::RGB_WHITE);
+          call.set_rgbw(1, 1, 1, 1);
+        }
+        call.perform();
+        return;
+      }
+      light->toggle().perform();
+    }
+  }
+
+  static void decTemperature(light::LightState* light) {
+    if (light) {
+      auto call = light->make_call();
+      call.set_color_mode(light::ColorMode::COLOR_TEMPERATURE);
+      if (!light->remote_values.is_on()) {
+        call.set_state(true);
+        call.set_brightness(0.1);
+      }
+      auto traits = light->get_traits();
+      float mired_step = static_cast<float>(traits.get_max_mireds() -
+                                            traits.get_min_mireds()) /
+                         20.0;
+      float color_temperature =
+          light->remote_values.get_color_temperature() - mired_step;
+      call.set_color_temperature(
+          std::max(traits.get_min_mireds(), color_temperature));
+      call.perform();
+    }
+  }
+
+  static void incTemperature(light::LightState* light) {
+    if (light) {
+      auto call = light->make_call();
+      call.set_color_mode(light::ColorMode::COLOR_TEMPERATURE);
+      if (!light->remote_values.is_on()) {
+        call.set_state(true);
+        call.set_brightness(0.1);
+      }
+      auto traits = light->get_traits();
+      float mired_step = static_cast<float>(traits.get_max_mireds() -
+                                            traits.get_min_mireds()) /
+                         20.0;
+      float color_temperature =
+          light->remote_values.get_color_temperature() + mired_step;
+      call.set_color_temperature(
+          std::min(traits.get_max_mireds(), color_temperature));
+      call.perform();
+    }
+  }
+  static void decBrightness(light::LightState* light) {
+    if (light) {
+      auto call = light->make_call();
+      auto brightness = light->remote_values.get_brightness() - 0.1;
+      if (brightness > 0) {
+        call.set_brightness(brightness);
+        ESP_LOGI(LIGHT_HELPERS_TAG, "'%s': brightness decreased to %f",
+                 light->get_name().c_str(), brightness);
+      } else {
+        call.set_state(false);
+        ESP_LOGI(LIGHT_HELPERS_TAG, "'%s': brightness decreased to off",
+                 light->get_name().c_str());
+      }
+      call.perform();
+    }
+  }
+  static void incBrightness(light::LightState* light) {
+    if (light) {
+      auto call = light->make_call();
+      if (light->remote_values.is_on()) {
+        auto brightness = light->remote_values.get_brightness() + 0.1;
+        call.set_brightness(std::min(1.0, brightness));
+        ESP_LOGI(LIGHT_HELPERS_TAG, "'%s': brightness increased to %f",
+                 light->get_name().c_str(), brightness);
+      } else {
+        call.set_state(true);
+        call.set_brightness(0.1);
+        ESP_LOGI(LIGHT_HELPERS_TAG, "'%s': brightness set to %f",
+                 light->get_name().c_str(), 0.1);
+      }
+      call.perform();
+    }
+  }
+  static void toggle(light::LightState* light) {
+    if (light) {
+      light->toggle().perform();
+    }
+  }
+
+  static void update_color_with_hsv(const float hsv_color,
+                                    light::LightState* light) {
+    if (light) {
+      auto call = light->make_call();
+      auto traits = light->get_traits();
+      if (traits.supports_color_mode(light::ColorMode::RGB)) {
+        call.set_color_mode(light::ColorMode::RGB);
+      } else if (traits.supports_color_mode(light::ColorMode::RGB_WHITE)) {
+        call.set_color_mode(light::ColorMode::RGB_WHITE);
+      } else {
+        ESP_LOGI(LIGHT_HELPERS_TAG, "'%s': doesnt support color!",
+                 light->get_name().c_str());
+        return;
+      }
+      if (!light->remote_values.is_on()) {
+        call.set_state(true);
+        call.set_brightness(0.1);
+      }
+      float red, green, blue;
+      hsv_to_rgb(hsv_color, 1, 1, red, green, blue);
+      call.set_rgb(red, green, blue);
+      call.perform();
+    }
+  }
+
+  static void decColor(light::LightState* light) {
+    if (light) {
+      float color_step = 360.0f / 20.0f;
+      float hsv_color = std::max(0.1f, get_hsv_color(light) - color_step);
+      update_color_with_hsv(hsv_color, light);
+    }
+  }
+  static void incColor(light::LightState* light) {
+    if (light) {
+      float color_step = 360.0f / 20.0f;
+      float hsv_color = std::min(359.9f, get_hsv_color(light) + color_step);
+      update_color_with_hsv(hsv_color, light);
+    }
+  }
+};
+}  // namespace homething_menu_base
+}  // namespace esphome

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -692,7 +692,8 @@ void HomeThingMenuBase::buttonPressSelectHold() {
 
 bool HomeThingMenuBase::upMenu() {
   if (menuTree.back() == lightsDetailMenu) {
-    active_menu_screen->set_selected_entity(nullptr);
+    if (active_menu_screen)
+      active_menu_screen->set_selected_entity(nullptr);
   }
   if (menuTree.size() > 1) {
     menuTree.pop_back();
@@ -883,9 +884,8 @@ void HomeThingMenuBase::buttonPressUp() {
   //   return;
   // }
   // option_menu_ = noOptionMenu;
-  if (active_menu_screen && active_menu_screen->get_selected_entity()) {
+  if (active_menu_screen)
     active_menu_screen->set_selected_entity(nullptr);
-  }
   topMenu();
   update_display();
 }
@@ -1306,7 +1306,8 @@ void HomeThingMenuBase::idleMenu(bool force) {
     return;
   }
   if (!get_charging() || force) {
-    active_menu_screen->set_selected_entity(nullptr);
+    if (active_menu_screen)
+      active_menu_screen->set_selected_entity(nullptr);
     reset_menu();
 #ifdef USE_MEDIA_PLAYER_GROUP
     menuTree.push_back(nowPlayingMenu);

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -16,20 +16,19 @@ void HomeThingMenuBase::setup() {
   this->display_update_tick_->add_on_state_callback(
       [this](float state) { this->displayUpdateDebounced(); });
 
-#ifdef USE_LIGHT_GROUP
-  if (this->light_group_) {
-    this->light_group_->add_on_state_callback([this](float state) {
-      switch (menuTree.back()) {
-        case lightsMenu:
-        case lightsDetailMenu:
-          reload_menu_items_ = true;
-          this->update_display();
-        default:
-          break;
-      }
-    });
-  }
-#endif
+// #ifdef USE_LIGHT_GROUP
+//   if (this->light_group_) {
+//     this->light_group_->add_on_state_callback([this](float state) {
+//       switch (menuTree.back()) {
+//         case lightsDetailMenu:
+//           reload_menu_items_ = true;
+//           this->update_display();
+//         default:
+//           break;
+//       }
+//     });
+//   }
+// #endif
 
 #ifdef USE_MEDIA_PLAYER_GROUP
   if (this->media_player_group_) {
@@ -178,12 +177,6 @@ bool HomeThingMenuBase::selectMenu() {
 #endif
       break;
     }
-    case lightsMenu: {
-#ifdef USE_LIGHT_GROUP
-      light_group_->toggleLight(menuIndex);
-#endif
-      return true;
-    }
     case lightsDetailMenu:
       editing_menu_item = true;
       break;
@@ -242,7 +235,6 @@ bool HomeThingMenuBase::selectMenuHold() {
           ESP_LOGI(TAG, "selectMenuHold: name %s", light->get_name().c_str());
           if (supportsBrightness(light)) {
             active_menu_screen->set_selected_entity(menu_item);
-            // light_group_->setActiveLight(light);
             menuIndex = 0;
             menuTree.push_back(lightsDetailMenu);
             return true;
@@ -276,11 +268,6 @@ std::vector<MenuStates> HomeThingMenuBase::rootMenuTitles() {
     out.push_back(sensorsMenu);
   }
 #endif
-#ifdef USE_LIGHT_GROUP
-  if (light_group_) {
-    out.push_back(lightsMenu);
-  }
-#endif
 
 #ifdef USE_SWITCH_GROUP
   if (switch_group_) {
@@ -306,9 +293,6 @@ bool HomeThingMenuBase::selectRootMenu() {
       break;
     case mediaPlayersMenu:
       menuTree.push_back(mediaPlayersMenu);
-      break;
-    case lightsMenu:
-      menuTree.push_back(lightsMenu);
       break;
     case switchesMenu:
       menuTree.push_back(switchesMenu);
@@ -420,11 +404,6 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuBase::activeMenu() {
       return sensorTitles(sensor_group_->sensors);
 #endif
       break;
-    case lightsMenu:
-#ifdef USE_LIGHT_GROUP
-      return lightTitleSwitches(light_group_->lights);
-#endif
-      break;
     case lightsDetailMenu: {
 #ifdef USE_LIGHT_GROUP
       auto selectedEntity = active_menu_screen->get_selected_entity();
@@ -436,11 +415,6 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuBase::activeMenu() {
       } else {
         return {};
       }
-      // if (light_group_->getActiveLight() != NULL) {
-      //   return lightTitleItems(light_group_->getActiveLight());
-      // } else {
-      //   return {};
-      // }
 #endif
       break;
     }
@@ -649,48 +623,6 @@ void HomeThingMenuBase::buttonPressSelectHold() {
     update_display();
   }
 }
-
-// #ifdef USE_LIGHT_GROUP
-// bool HomeThingMenuBase::sliderScrollBack() {
-//   if (editing_menu_item && menuIndex == 0 &&
-//       active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->decBrightness();
-//     debounceUpdateDisplay();
-//     return true;
-//   } else if (editing_menu_item && menuIndex == 1 &&
-//              active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->decTemperature();
-//     debounceUpdateDisplay();
-//     return true;
-//   } else if (editing_menu_item && menuIndex == 2 &&
-//              active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->decColor();
-//     debounceUpdateDisplay();
-//     return true;
-//   }
-//   return false;
-// }
-
-// bool HomeThingMenuBase::sliderScrollForward() {
-//   if (editing_menu_item && menuIndex == 0 &&
-//       active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->incBrightness();
-//     debounceUpdateDisplay();
-//     return true;
-//   } else if (editing_menu_item && menuIndex == 1 &&
-//              active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->incTemperature();
-//     debounceUpdateDisplay();
-//     return true;
-//   } else if (editing_menu_item && menuIndex == 2 &&
-//              active_menu_screen->get_selected_entity() != NULL) {
-//     light_group_->incColor();
-//     debounceUpdateDisplay();
-//     return true;
-//   }
-//   return false;
-// }
-// #endif
 
 bool HomeThingMenuBase::upMenu() {
   if (menuTree.back() == lightsDetailMenu) {
@@ -1125,7 +1057,6 @@ void HomeThingMenuBase::buttonPressScreenRight() {
     case groupMenu:
     case mediaPlayersMenu:
     case scenesMenu:
-    case lightsMenu:
     case lightsDetailMenu:
     case sensorsMenu:
     case bootMenu:

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -16,19 +16,19 @@ void HomeThingMenuBase::setup() {
   this->display_update_tick_->add_on_state_callback(
       [this](float state) { this->displayUpdateDebounced(); });
 
-// #ifdef USE_LIGHT_GROUP
-//   if (this->light_group_) {
-//     this->light_group_->add_on_state_callback([this](float state) {
-//       switch (menuTree.back()) {
-//         case lightsDetailMenu:
-//           reload_menu_items_ = true;
-//           this->update_display();
-//         default:
-//           break;
-//       }
-//     });
-//   }
-// #endif
+  // #ifdef USE_LIGHT_GROUP
+  //   if (this->light_group_) {
+  //     this->light_group_->add_on_state_callback([this](float state) {
+  //       switch (menuTree.back()) {
+  //         case lightsDetailMenu:
+  //           reload_menu_items_ = true;
+  //           this->update_display();
+  //         default:
+  //           break;
+  //       }
+  //     });
+  //   }
+  // #endif
 
 #ifdef USE_MEDIA_PLAYER_GROUP
   if (this->media_player_group_) {

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -876,17 +876,16 @@ void HomeThingMenuBase::buttonPressUp() {
     default:
       break;
   }
-// if (option_menu_ == speakerOptionMenu) {
-//   media_player_group_->toggle_shuffle();
-//   option_menu_ = noOptionMenu;
-//   update_display();
-//   return;
-// }
-// option_menu_ = noOptionMenu;
-#ifdef USE_LIGHT_GROUP
-  if (light_group_)
+  // if (option_menu_ == speakerOptionMenu) {
+  //   media_player_group_->toggle_shuffle();
+  //   option_menu_ = noOptionMenu;
+  //   update_display();
+  //   return;
+  // }
+  // option_menu_ = noOptionMenu;
+  if (active_menu_screen && active_menu_screen->get_selected_entity()) {
     active_menu_screen->set_selected_entity(nullptr);
-#endif
+  }
   topMenu();
   update_display();
 }

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -214,6 +214,9 @@ bool HomeThingMenuBase::selectMenu() {
       break;
     case settingsMenu:
       if (active_menu_screen && active_menu_screen->select_menu(menuIndex)) {
+        if (active_menu_screen->get_selected_entity()) {
+          editing_menu_item = true;
+        }
         update_display();
       }
       break;
@@ -577,7 +580,7 @@ void HomeThingMenuBase::buttonPressSelect() {
   if (menu_settings_->get_mode() == MENU_MODE_ROTARY) {
     switch (menuTree.back()) {
       case lightsDetailMenu:
-#ifdef USE_LIGHT_GROUP
+      case settingsMenu:
         if (editing_menu_item) {
           // deselect light if selected and stay in lightsDetailMenu
           editing_menu_item = false;
@@ -585,7 +588,6 @@ void HomeThingMenuBase::buttonPressSelect() {
           update_display();
           return;
         }
-#endif
         break;
       case nowPlayingMenu:
 #ifdef USE_MEDIA_PLAYER_GROUP
@@ -728,6 +730,17 @@ void HomeThingMenuBase::rotaryScrollCounterClockwise(int rotary) {
           return;
         }
 #endif
+      case settingsMenu:
+        if (editing_menu_item && active_menu_screen &&
+            active_menu_screen->get_selected_entity() &&
+            HomeThingMenuControls::editingScrollBack(
+                active_menu_screen->get_selected_entity(), menuIndex,
+                editing_menu_item)) {
+          reload_menu_items_ = true;
+          debounceUpdateDisplay();
+          return;
+        }
+        break;
       default:
         break;
     }
@@ -791,6 +804,16 @@ void HomeThingMenuBase::rotaryScrollClockwise(int rotary) {
           return;
         }
 #endif
+      case settingsMenu:
+        if (editing_menu_item && active_menu_screen &&
+            active_menu_screen->get_selected_entity() &&
+            HomeThingMenuControls::editingScrollForward(
+                active_menu_screen->get_selected_entity(), menuIndex,
+                editing_menu_item)) {
+          reload_menu_items_ = true;
+          debounceUpdateDisplay();
+          return;
+        }
       default:
         break;
     }
@@ -875,6 +898,13 @@ void HomeThingMenuBase::buttonPressUp() {
 #endif
       break;
     default:
+    case settingsMenu:
+      if (editing_menu_item) {
+        editing_menu_item = false;
+        reload_menu_items_ = true;
+        update_display();
+        return;
+      }
       break;
   }
   // if (option_menu_ == speakerOptionMenu) {

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -7,6 +7,7 @@
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/homeThing/homeThingMenuAnimation.h"
 #include "esphome/components/homeThing/homeThingMenuBoot.h"
+#include "esphome/components/homeThing/homeThingMenuControls.h"
 #include "esphome/components/homeThing/homeThingMenuDisplay.h"
 #include "esphome/components/homeThing/homeThingMenuDisplayState.h"
 #include "esphome/components/homeThing/homeThingMenuHeader.h"
@@ -146,8 +147,6 @@ class HomeThingMenuBase : public PollingComponent {
   bool button_press_now_playing_option_continue(
       CircleOptionMenuPosition position);
 #endif
-  bool sliderScrollBack();
-  bool sliderScrollForward();
   bool upMenu();
   void rotaryScrollClockwise(int rotary);
   void rotaryScrollCounterClockwise(int rotary);
@@ -293,6 +292,7 @@ class HomeThingMenuBase : public PollingComponent {
   bool device_locked_ = false;
   int unlock_presses_ = 0;
   void finish_boot();
+  bool editing_menu_item = false;
 };  // namespace homething_menu_base
 
 class HomeThingDisplayMenuOnRedrawTrigger

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -48,7 +48,9 @@ class HomeThingMenuBase : public PollingComponent {
  public:
   HomeThingMenuBase(HomeThingMenuSettings* menu_settings,
                     HomeThingMenuDisplay* menu_display)
-      : menu_settings_(menu_settings), menu_display_(menu_display) {}
+      : menu_settings_(menu_settings), menu_display_(menu_display) {
+    menu_display_->set_active_menu_screen(&active_menu_screen);
+  }
   void setup();
 
   void set_charging(binary_sensor::BinarySensor* charging) {

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -263,6 +263,7 @@ class HomeThingMenuBase : public PollingComponent {
     menuIndex = 0;
     active_menu_screen = nullptr;
     reload_menu_items_ = true;
+    editing_menu_item = false;
 #ifdef USE_MEDIA_PLAYER_GROUP
     circle_menu_->clear_active_menu();
 #endif

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -15,10 +15,6 @@
 #include "esphome/components/homeThing/homeThingMenuSettings.h"
 #include "esphome/components/homeThing/homeThingMenuTitle.h"
 
-#ifdef USE_LIGHT_GROUP
-#include "esphome/components/homeassistant_light_group/HomeAssistantLightGroup.h"
-#endif
-
 #ifdef USE_MEDIA_PLAYER_GROUP
 #include "esphome/components/homeThing/homeThingMenuNowPlaying.h"
 #include "esphome/components/homeThing/homeThingMenuNowPlayingOptionMenu.h"
@@ -97,16 +93,6 @@ class HomeThingMenuBase : public PollingComponent {
       homeassistant_media_player::HomeAssistantMediaPlayerGroup*
           media_player_group) {
     media_player_group_ = media_player_group;
-  }
-#endif
-
-#ifdef USE_LIGHT_GROUP
-  homeassistant_light_group::HomeAssistantLightGroup* get_light_group() {
-    return light_group_;
-  }
-  void set_light_group(
-      homeassistant_light_group::HomeAssistantLightGroup* light_group) {
-    light_group_ = light_group;
   }
 #endif
 
@@ -240,10 +226,6 @@ class HomeThingMenuBase : public PollingComponent {
   void selectNowPlayingMenu();
   HomeThingMenuNowPlayingOptionMenu* circle_menu_ =
       new HomeThingMenuNowPlayingOptionMenu();
-#endif
-
-#ifdef USE_LIGHT_GROUP
-  homeassistant_light_group::HomeAssistantLightGroup* light_group_{nullptr};
 #endif
 
 #ifdef USE_SWITCH_GROUP

--- a/components/homeThing/homeThingMenuControls.h
+++ b/components/homeThing/homeThingMenuControls.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "esphome/components/homeThing/homeThingLightHelpers.h"
+#include "esphome/components/homeThing/homeThingMenuScreen.h"
+#include "esphome/components/homeThing/homeThingMenuTitle.h"
+
+namespace esphome {
+namespace homething_menu_base {
+
+static const char* const MENU_CONTROLS_TAG = "homething.menu.controls";
+
+class HomeThingMenuControls {
+ public:
+  static bool editingScrollBack(
+      const std::tuple<MenuItemType, EntityBase*>* entity, int menuIndex,
+      bool editing_menu_item) {
+    MenuItemType menu_item_type = std::get<0>(*entity);
+    if (menu_item_type == MenuItemTypeLight) {
+      auto light = static_cast<light::LightState*>(std::get<1>(*entity));
+      if (editing_menu_item && menuIndex == 0 && entity != NULL) {
+        HomeThingLightHelpers::decBrightness(light);
+        return true;
+      } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
+        HomeThingLightHelpers::decTemperature(light);
+        return true;
+      } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
+        HomeThingLightHelpers::decColor(light);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static bool editingScrollForward(
+      const std::tuple<MenuItemType, EntityBase*>* entity, int menuIndex,
+      bool editing_menu_item) {
+    MenuItemType menu_item_type = std::get<0>(*entity);
+    if (menu_item_type == MenuItemTypeLight) {
+      auto light = static_cast<light::LightState*>(std::get<1>(*entity));
+      if (editing_menu_item && menuIndex == 0 && entity != NULL) {
+        HomeThingLightHelpers::incBrightness(light);
+        return true;
+      } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
+        HomeThingLightHelpers::incTemperature(light);
+        return true;
+      } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
+        HomeThingLightHelpers::incColor(light);
+        return true;
+      }
+    }
+    return false;
+  }
+};
+}  // namespace homething_menu_base
+}  // namespace esphome

--- a/components/homeThing/homeThingMenuControls.h
+++ b/components/homeThing/homeThingMenuControls.h
@@ -17,6 +17,7 @@ class HomeThingMenuControls {
     MenuItemType menu_item_type = std::get<0>(*entity);
     switch (menu_item_type) {
       case MenuItemTypeLight: {
+        #ifdef USE_LIGHT
         auto light = static_cast<light::LightState*>(std::get<1>(*entity));
         if (editing_menu_item && menuIndex == 0 && entity != NULL) {
           HomeThingLightHelpers::decBrightness(light);
@@ -28,13 +29,18 @@ class HomeThingMenuControls {
           HomeThingLightHelpers::decColor(light);
           return true;
         }
+        #endif
+        break;
       }
       case MenuItemTypeNumber: {
+        #ifdef USE_NUMBER
         if (editing_menu_item) {
           auto number = static_cast<number::Number*>(std::get<1>(*entity));
           number->make_call().number_decrement(false).perform();
           return true;
         }
+        #endif
+        break;
       }
       default:
         break;
@@ -48,6 +54,7 @@ class HomeThingMenuControls {
     MenuItemType menu_item_type = std::get<0>(*entity);
     switch (menu_item_type) {
       case MenuItemTypeLight: {
+        #ifdef USE_LIGHT
         auto light = static_cast<light::LightState*>(std::get<1>(*entity));
         if (editing_menu_item && menuIndex == 0 && entity != NULL) {
           HomeThingLightHelpers::incBrightness(light);
@@ -59,13 +66,18 @@ class HomeThingMenuControls {
           HomeThingLightHelpers::incColor(light);
           return true;
         }
+        #endif
+        break;
       }
       case MenuItemTypeNumber: {
+        #ifdef USE_NUMBER
         if (editing_menu_item) {
           auto number = static_cast<number::Number*>(std::get<1>(*entity));
           number->make_call().number_increment(false).perform();
           return true;
         }
+        #endif
+        break;
       }
       default:
         break;

--- a/components/homeThing/homeThingMenuControls.h
+++ b/components/homeThing/homeThingMenuControls.h
@@ -15,18 +15,29 @@ class HomeThingMenuControls {
       const std::tuple<MenuItemType, EntityBase*>* entity, int menuIndex,
       bool editing_menu_item) {
     MenuItemType menu_item_type = std::get<0>(*entity);
-    if (menu_item_type == MenuItemTypeLight) {
-      auto light = static_cast<light::LightState*>(std::get<1>(*entity));
-      if (editing_menu_item && menuIndex == 0 && entity != NULL) {
-        HomeThingLightHelpers::decBrightness(light);
-        return true;
-      } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
-        HomeThingLightHelpers::decTemperature(light);
-        return true;
-      } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
-        HomeThingLightHelpers::decColor(light);
-        return true;
+    switch (menu_item_type) {
+      case MenuItemTypeLight: {
+        auto light = static_cast<light::LightState*>(std::get<1>(*entity));
+        if (editing_menu_item && menuIndex == 0 && entity != NULL) {
+          HomeThingLightHelpers::decBrightness(light);
+          return true;
+        } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
+          HomeThingLightHelpers::decTemperature(light);
+          return true;
+        } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
+          HomeThingLightHelpers::decColor(light);
+          return true;
+        }
       }
+      case MenuItemTypeNumber: {
+        if (editing_menu_item) {
+          auto number = static_cast<number::Number*>(std::get<1>(*entity));
+          number->make_call().number_decrement(false).perform();
+          return true;
+        }
+      }
+      default:
+        break;
     }
     return false;
   }
@@ -35,18 +46,29 @@ class HomeThingMenuControls {
       const std::tuple<MenuItemType, EntityBase*>* entity, int menuIndex,
       bool editing_menu_item) {
     MenuItemType menu_item_type = std::get<0>(*entity);
-    if (menu_item_type == MenuItemTypeLight) {
-      auto light = static_cast<light::LightState*>(std::get<1>(*entity));
-      if (editing_menu_item && menuIndex == 0 && entity != NULL) {
-        HomeThingLightHelpers::incBrightness(light);
-        return true;
-      } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
-        HomeThingLightHelpers::incTemperature(light);
-        return true;
-      } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
-        HomeThingLightHelpers::incColor(light);
-        return true;
+    switch (menu_item_type) {
+      case MenuItemTypeLight: {
+        auto light = static_cast<light::LightState*>(std::get<1>(*entity));
+        if (editing_menu_item && menuIndex == 0 && entity != NULL) {
+          HomeThingLightHelpers::incBrightness(light);
+          return true;
+        } else if (editing_menu_item && menuIndex == 1 && entity != NULL) {
+          HomeThingLightHelpers::incTemperature(light);
+          return true;
+        } else if (editing_menu_item && menuIndex == 2 && entity != NULL) {
+          HomeThingLightHelpers::incColor(light);
+          return true;
+        }
       }
+      case MenuItemTypeNumber: {
+        if (editing_menu_item) {
+          auto number = static_cast<number::Number*>(std::get<1>(*entity));
+          number->make_call().number_increment(false).perform();
+          return true;
+        }
+      }
+      default:
+        break;
     }
     return false;
   }

--- a/components/homeThing/homeThingMenuControls.h
+++ b/components/homeThing/homeThingMenuControls.h
@@ -17,7 +17,7 @@ class HomeThingMenuControls {
     MenuItemType menu_item_type = std::get<0>(*entity);
     switch (menu_item_type) {
       case MenuItemTypeLight: {
-        #ifdef USE_LIGHT
+#ifdef USE_LIGHT
         auto light = static_cast<light::LightState*>(std::get<1>(*entity));
         if (editing_menu_item && menuIndex == 0 && entity != NULL) {
           HomeThingLightHelpers::decBrightness(light);
@@ -29,17 +29,17 @@ class HomeThingMenuControls {
           HomeThingLightHelpers::decColor(light);
           return true;
         }
-        #endif
+#endif
         break;
       }
       case MenuItemTypeNumber: {
-        #ifdef USE_NUMBER
+#ifdef USE_NUMBER
         if (editing_menu_item) {
           auto number = static_cast<number::Number*>(std::get<1>(*entity));
           number->make_call().number_decrement(false).perform();
           return true;
         }
-        #endif
+#endif
         break;
       }
       default:
@@ -54,7 +54,7 @@ class HomeThingMenuControls {
     MenuItemType menu_item_type = std::get<0>(*entity);
     switch (menu_item_type) {
       case MenuItemTypeLight: {
-        #ifdef USE_LIGHT
+#ifdef USE_LIGHT
         auto light = static_cast<light::LightState*>(std::get<1>(*entity));
         if (editing_menu_item && menuIndex == 0 && entity != NULL) {
           HomeThingLightHelpers::incBrightness(light);
@@ -66,17 +66,17 @@ class HomeThingMenuControls {
           HomeThingLightHelpers::incColor(light);
           return true;
         }
-        #endif
+#endif
         break;
       }
       case MenuItemTypeNumber: {
-        #ifdef USE_NUMBER
+#ifdef USE_NUMBER
         if (editing_menu_item) {
           auto number = static_cast<number::Number*>(std::get<1>(*entity));
           number->make_call().number_increment(false).perform();
           return true;
         }
-        #endif
+#endif
         break;
       }
       default:

--- a/components/homeThing/homeThingMenuDisplay.cpp
+++ b/components/homeThing/homeThingMenuDisplay.cpp
@@ -76,7 +76,7 @@ void HomeThingMenuDisplay::draw_lock_screen(int unlock_presses) {
 
 bool HomeThingMenuDisplay::draw_menu_titles(
     const std::vector<std::shared_ptr<MenuTitleBase>>* menuTitles,
-    int menuIndex) {
+    int menuIndex, bool editing_menu_item) {
   if (menuTitles->size() == 0 || menuTitles->size() < menuIndex) {
     return false;
   }
@@ -142,12 +142,11 @@ bool HomeThingMenuDisplay::draw_menu_titles(
       }
       case SliderMenuTitleType: {
 #ifdef USE_LIGHT_GROUP
-        bool lightDetailSelected = light_group_->lightDetailSelected;
         auto item = std::static_pointer_cast<MenuTitleSlider>((*menuTitles)[i]);
         SliderSelectionState sliderState =
-            menuState == i && lightDetailSelected ? SliderSelectionStateActive
-            : menuState == i                      ? SliderSelectionStateHover
-                                                  : SliderSelectionStateNone;
+            menuState == i && editing_menu_item ? SliderSelectionStateActive
+            : menuState == i                    ? SliderSelectionStateHover
+                                                : SliderSelectionStateNone;
         refactor_->drawLightSlider(0, yPos, sliderState, item, i == 2);
         sliderExtra += 0;
 
@@ -186,7 +185,8 @@ bool HomeThingMenuDisplay::draw_menu_titles(
 bool HomeThingMenuDisplay::draw_menu_screen(
     MenuStates* activeMenuState,
     const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu,
-    const int menuIndex, HomeThingOptionMenu* option_menu) {
+    const int menuIndex, HomeThingOptionMenu* option_menu,
+    bool editing_menu_item) {
   bool boot_complete = boot_->boot_complete();
   if (!display_state_->get_dark_mode() && *activeMenuState != bootMenu) {
     display_buffer_->fill(display_state_->get_color_palette()->get_white());
@@ -210,7 +210,7 @@ bool HomeThingMenuDisplay::draw_menu_screen(
 #endif
       break;
     default:
-      animating = draw_menu_titles(active_menu, menuIndex);
+      animating = draw_menu_titles(active_menu, menuIndex, editing_menu_item);
       break;
   }
   header_->drawHeader(0, *activeMenuState);

--- a/components/homeThing/homeThingMenuDisplay.cpp
+++ b/components/homeThing/homeThingMenuDisplay.cpp
@@ -93,6 +93,9 @@ bool HomeThingMenuDisplay::draw_menu_titles(
     }
     auto rightIconState = (*menuTitles)[i]->rightIconState;
     auto titleName = (*menuTitles)[i]->get_name();
+    if (i == menuIndex && editing_menu_item) {
+      titleName = "*" + titleName;
+    }
     ESP_LOGD(TAG, "draw_menu_titles: %s", titleName.c_str());
     switch ((*menuTitles)[i]->titleType) {
       case BaseMenuTitleType:

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -90,6 +90,9 @@ class HomeThingMenuDisplay {
   }
 #endif
   HomeThingMenuBoot* boot_{nullptr};
+  void set_active_menu_screen(HomeThingMenuScreen** active_menu_screen) {
+    header_->set_active_menu_screen(active_menu_screen);
+  }
 
  private:
   int scrollTop = 0;

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -83,12 +83,6 @@ class HomeThingMenuDisplay {
   }
 #endif
 
-#ifdef USE_LIGHT_GROUP
-  void set_light_group(
-      homeassistant_light_group::HomeAssistantLightGroup* light_group) {
-    light_group_ = light_group;
-  }
-#endif
   HomeThingMenuBoot* boot_{nullptr};
   void set_active_menu_screen(HomeThingMenuScreen** active_menu_screen) {
     header_->set_active_menu_screen(active_menu_screen);
@@ -127,9 +121,6 @@ class HomeThingMenuDisplay {
       media_player_group_{nullptr};
 #endif
 
-#ifdef USE_LIGHT_GROUP
-  homeassistant_light_group::HomeAssistantLightGroup* light_group_{nullptr};
-#endif
   const char* const TAG = "homething.menu.display";
 };
 

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -63,7 +63,8 @@ class HomeThingMenuDisplay {
   bool draw_menu_screen(
       MenuStates* activeMenuState,
       const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu,
-      const int menuIndex, HomeThingOptionMenu* option_menu);
+      const int menuIndex, HomeThingOptionMenu* option_menu,
+      bool editing_menu_item);
   void updateDisplay(bool force);
 
   void set_animation(HomeThingMenuAnimation* animation) {
@@ -94,7 +95,7 @@ class HomeThingMenuDisplay {
   int scrollTop = 0;
   bool draw_menu_titles(
       const std::vector<std::shared_ptr<MenuTitleBase>>* menuTitles,
-      const int menuIndex);
+      const int menuIndex, bool editing_menu_item);
   bool draw_menu_title(int menuState, int i, std::string title, int yPos,
                        bool buttonSpace);
   void drawScrollBar(int menuTitlesCount, int headerHeight, int menuIndex);

--- a/components/homeThing/homeThingMenuHeader.cpp
+++ b/components/homeThing/homeThingMenuHeader.cpp
@@ -66,8 +66,11 @@ void HomeThingMenuHeader::drawHeaderTitle(int yPosOffset,
       break;
     case lightsDetailMenu: {
 #ifdef USE_LIGHT_GROUP
-      if (light_group_->getActiveLight() != NULL) {
-        auto activeLight = light_group_->getActiveLight();
+      auto selectedEntity = (*active_menu_screen_)->get_selected_entity();
+      if (selectedEntity != NULL &&
+          std::get<0>(*selectedEntity) == MenuItemTypeLight) {
+        auto activeLight =
+            static_cast<light::LightState*>(std::get<1>(*selectedEntity));
         auto headerMenuTitle = activeLight->get_name();
         int newXPos =
             drawHeaderIcon(icon(activeLight), xPos, rgbLightColor(activeLight));

--- a/components/homeThing/homeThingMenuHeader.h
+++ b/components/homeThing/homeThingMenuHeader.h
@@ -48,13 +48,6 @@ class HomeThingMenuHeader {
   }
 #endif
 
-#ifdef USE_LIGHT_GROUP
-  void set_light_group(
-      homeassistant_light_group::HomeAssistantLightGroup* light_group) {
-    light_group_ = light_group;
-  }
-#endif
-
  private:
   float get_battery_percent() {
     if (battery_percent_ != nullptr && battery_percent_->has_state()) {
@@ -88,10 +81,6 @@ class HomeThingMenuHeader {
 #ifdef USE_MEDIA_PLAYER_GROUP
   homeassistant_media_player::HomeAssistantMediaPlayerGroup*
       media_player_group_{nullptr};
-#endif
-
-#ifdef USE_LIGHT_GROUP
-  homeassistant_light_group::HomeAssistantLightGroup* light_group_{nullptr};
 #endif
 
   display::DisplayBuffer* display_buffer_{nullptr};

--- a/components/homeThing/homeThingMenuHeader.h
+++ b/components/homeThing/homeThingMenuHeader.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "esphome/components/homeThing/homeThingMenuDisplayState.h"
+#include "esphome/components/homeThing/homeThingMenuScreen.h"
 #include "esphome/components/homeThing/homeThingMenuTextHelpers.h"
 #include "esphome/components/homeThing/homeThingMenuTitle.h"
 
@@ -34,6 +35,9 @@ class HomeThingMenuHeader {
   }
   void set_charging(binary_sensor::BinarySensor* charging) {
     charging_ = charging;
+  }
+  void set_active_menu_screen(HomeThingMenuScreen** active_menu_screen) {
+    active_menu_screen_ = active_menu_screen;
   }
 
 #ifdef USE_MEDIA_PLAYER_GROUP
@@ -97,6 +101,7 @@ class HomeThingMenuHeader {
   binary_sensor::BinarySensor* charging_{nullptr};
   time::RealTimeClock* esp_time_{nullptr};
   const char* const TAG = "homething.menu.header";
+  HomeThingMenuScreen** active_menu_screen_{nullptr};
 };
 
 }  // namespace homething_menu_base

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -19,8 +19,8 @@
 #endif
 
 #ifdef USE_LIGHT
-#include "esphome/components/light/light_state.h"
 #include "esphome/components/homeThing/homeThingMenuTitleLight.h"
+#include "esphome/components/light/light_state.h"
 #endif
 
 #ifdef USE_NUMBER

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -19,6 +19,7 @@
 #endif
 
 #ifdef USE_LIGHT
+#include "esphome/components/light/light_state.h"
 #include "esphome/components/homeThing/homeThingMenuTitleLight.h"
 #endif
 

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -22,6 +22,10 @@
 #include "esphome/components/homeThing/homeThingMenuTitleLight.h"
 #endif
 
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+
 namespace esphome {
 namespace homething_menu_base {
 
@@ -50,7 +54,8 @@ enum MenuItemType {
   MenuItemTypeTextSensor,
   MenuItemTypeCommand,
   MenuItemTypeSensor,
-  MenuItemTypeLight
+  MenuItemTypeLight,
+  MenuItemTypeNumber
 };
 
 class HomeThingMenuScreen {
@@ -61,6 +66,13 @@ class HomeThingMenuScreen {
   void set_index(int index) { index_ = index; }
   int get_index() { return index_; }
   void set_show_version(bool show_version) { show_version_ = show_version; }
+  void set_selected_entity(
+      const std::tuple<MenuItemType, EntityBase*>* entity) {
+    selected_entity_ = entity;
+  }
+  const std::tuple<MenuItemType, EntityBase*>* get_selected_entity() {
+    return selected_entity_;
+  }
 
 #ifdef USE_SWITCH
   void register_switch(switch_::Switch* new_switch) {
@@ -94,6 +106,12 @@ class HomeThingMenuScreen {
 #ifdef USE_LIGHT
   void register_light(light::LightState* new_light) {
     entities_.push_back(std::make_tuple(MenuItemTypeLight, new_light));
+  }
+#endif
+
+#ifdef USE_NUMBER
+  void register_number(number::Number* new_number) {
+    entities_.push_back(std::make_tuple(MenuItemTypeNumber, new_number));
   }
 #endif
 
@@ -175,7 +193,7 @@ class HomeThingMenuScreen {
         case MenuItemTypeLight: {
 #ifdef USE_LIGHT
           auto light = static_cast<light::LightState*>(std::get<1>(entity));
-          auto output = static_cast<light::LightOutput*>(light->get_output());
+          // auto output = static_cast<light::LightOutput*>(light->get_output());
           MenuTitleLeftIcon state = light->remote_values.is_on()
                                         ? OnMenuTitleLeftIcon
                                         : OffMenuTitleLeftIcon;
@@ -185,6 +203,21 @@ class HomeThingMenuScreen {
           out.push_back(std::make_shared<MenuTitleLight>(
               light->get_name(), "", state, rightIcon,
               light::rgbLightColor(light)));
+#endif
+          break;
+        }
+        case MenuItemTypeNumber: {
+#ifdef USE_NUMBER
+          auto number = static_cast<number::Number*>(std::get<1>(entity));
+          auto state = to_string(number->state).c_str();
+          if (number->get_name() != "") {
+            out.push_back(std::make_shared<MenuTitleBase>(
+                number->get_name() + ": " + state, "", NoMenuTitleRightIcon));
+          } else {
+            out.push_back(std::make_shared<MenuTitleBase>(
+                number->get_object_id() + ": " + state, "",
+                NoMenuTitleRightIcon));
+          }
 #endif
           break;
         }
@@ -244,20 +277,24 @@ class HomeThingMenuScreen {
 #endif
         return true;
       }
+      case MenuItemTypeNumber: {
+        ESP_LOGI(MENU_TITLE_SCREEN_TAG, "selected number %d", index);
+        return false;
+      }
     }
     return false;
   }
 
   bool select_menu_hold(int index) {
     if (index == 0) {
-      ESP_LOGI(MENU_TITLE_SCREEN_TAG, "selected name %d", index);
+      ESP_LOGI(MENU_TITLE_SCREEN_TAG, "select hold name %d", index);
       return false;
     }
     index -= 1;
 #ifdef SHOW_VERSION
     if (show_version_) {
       if (index == 0) {
-        ESP_LOGI(MENU_TITLE_SCREEN_TAG, "selected version %d", index);
+        ESP_LOGI(MENU_TITLE_SCREEN_TAG, "select hold version %d", index);
         return false;
       }
       index -= 1;
@@ -266,7 +303,7 @@ class HomeThingMenuScreen {
     return false;
   }
 
-  std::tuple<MenuItemType, EntityBase*>* get_menu_item(int index) {
+  const std::tuple<MenuItemType, EntityBase*>* get_menu_item(int index) {
     // name isnt an entity
     index -= 1;
 #ifdef SHOW_VERSION
@@ -282,6 +319,7 @@ class HomeThingMenuScreen {
   bool show_version_ = false;
   std::string name_;
   std::vector<std::tuple<MenuItemType, EntityBase*>> entities_;
+  const std::tuple<MenuItemType, EntityBase*>* selected_entity_;
 };
 
 }  // namespace homething_menu_base

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -279,7 +279,9 @@ class HomeThingMenuScreen {
       }
       case MenuItemTypeNumber: {
         ESP_LOGI(MENU_TITLE_SCREEN_TAG, "selected number %d", index);
-        return false;
+        auto entity = &entities_[index];
+        set_selected_entity(entity);
+        return true;
       }
     }
     return false;

--- a/components/homeThing/homeThingMenuTitleLight.h
+++ b/components/homeThing/homeThingMenuTitleLight.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#ifdef USE_LIGHT_GROUP
-#include "esphome/components/homeassistant_light_group/HomeAssistantLightGroup.h"
-#include "esphome/components/homeassistant_light_group/LightExtensions.h"
+#ifdef USE_LIGHT
+#include "esphome/components/homeassistant_component/LightExtensions.h"
 #endif
 #include "esphome/components/homeThing/homeThingMenuTitle.h"
 
@@ -12,7 +11,7 @@ namespace homething_menu_base {
 static const char* const MENU_TITLE_LIGHT_TAG = "homething.menutitle.light";
 
 // light
-#ifdef USE_LIGHT_GROUP
+#ifdef USE_LIGHT
 #define MAX_BRIGHTNESS 255.0f
 
 class MenuTitleLight : public MenuTitleToggle {

--- a/example-homeThing.yaml
+++ b/example-homeThing.yaml
@@ -23,10 +23,13 @@ substitutions:
 # switch menu
 switch:
   # replace with your switchs
-    - platform: homeassistant_switch_group
-      entity_id: "switch.oven_fan"
-      name: "Oven Fan"
-      id: oven_fan_switch
+  - platform: homeassistant_switch_group
+    entity_id: "switch.oven_fan"
+    name: "Oven Fan"
+    id: oven_fan_switch
+  - platform: restart
+    id: restart_switch
+    name: "${friendly_name} Restart"
 
 homeassistant_switch_group:
   # defined above with switches
@@ -48,15 +51,10 @@ homeassistant_sensor_group:
 
 # light menu
 light:
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_office_lamp
     entity_id: light.office_lamp
     name: Office Lamp
-
-homeassistant_light_group:
-  id: light_group_component
-  lights:
-    - id: light_office_lamp
 
 # sonos favorite source
 media_player_source_sonos:
@@ -110,9 +108,8 @@ homeThing:
   battery: #optional
     battery_percent: battery_percent
     charging: charging
-   # need atleast 1 group_component
+   # need atleast 1 group_component or screen
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component
@@ -130,6 +127,20 @@ homeThing:
     font_material_large: material_font_large
     font_material_small: material_font_small
     font_logo: home_thing_logo
+  screens:
+    - name: Settings Screen
+      show_version: True
+      entities:
+        - id: backlight
+          type: light
+        - id: "restart_switch"
+          type: switch
+        - id: wifi_ssid
+          type: text_sensor
+        - id: wifi_signal_percent
+          type: sensor
+        - id: wifi_ip
+          type: text_sensor
 
 # maybe modify: display setup
 spi:
@@ -182,7 +193,6 @@ external_components:
       homeassistant_component, # required for all components
       homeassistant_switch_group, # only include if you use switches
       homeassistant_sensor_group, # only include if you use text sensors in menu
-      homeassistant_light_group, # only include if you use lights
       homeassistant_media_player, # only include if you use media players
       homeassistant_service_group, # only include if you want to call services/scripts
       media_player_source, # required for all media player sources

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -46,7 +46,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -177,7 +177,6 @@ homeThing:
     battery_percent: battery_percent
     charging: connected
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/homeConfig/light.yaml
+++ b/homeConfig/light.yaml
@@ -1,35 +1,25 @@
 light:
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_rgb_lights
     entity_id: light.rgb_lights
     name: Color Lights 
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_living_room_lights
     entity_id: light.living_room_lights
     name: Living Room 
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_desk_lamp
     entity_id: light.desk_lamp
     name: Desk Lamp
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_kitchen_lights
     entity_id: light.kitchen_lights
     name: Kitchen
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_bathroom_lights
     entity_id: light.bathroom_lights
     name: Bathroom
-  - platform: homeassistant_light_group
+  - platform: homeassistant_component
     id: light_bedroom_lights
     entity_id: light.bedroom_lights
     name: Bedroom
-
-homeassistant_light_group:
-  id: light_group_component
-  lights:
-    - id: light_rgb_lights
-    - id: light_living_room_lights
-    - id: light_desk_lamp
-    - id: light_kitchen_lights
-    - id: light_bathroom_lights
-    - id: light_bedroom_lights

--- a/homething-lilygo.yaml
+++ b/homething-lilygo.yaml
@@ -101,7 +101,6 @@ homeThing:
     battery_percent: battery_percent
     charging: charging
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/homething-lilygo.yaml
+++ b/homething-lilygo.yaml
@@ -42,7 +42,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,

--- a/m5stickc.yaml
+++ b/m5stickc.yaml
@@ -56,7 +56,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,

--- a/m5stickc.yaml
+++ b/m5stickc.yaml
@@ -190,7 +190,6 @@ spi:
 homeThing:
   id: homeThingMenu
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/m5stickcplus.yaml
+++ b/m5stickcplus.yaml
@@ -55,7 +55,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,
@@ -237,7 +236,6 @@ homeThing:
   #   battery_percent: battery_percent
   #   charging: axp_charger
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   switch_group: switch_group_component
   display: my_display

--- a/tdisplayremote.yaml
+++ b/tdisplayremote.yaml
@@ -81,7 +81,6 @@ homeThing:
     battery_percent: battery_percent
     charging: charging
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/tdisplayremote.yaml
+++ b/tdisplayremote.yaml
@@ -42,7 +42,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,

--- a/tdisplayt4.yaml
+++ b/tdisplayt4.yaml
@@ -35,7 +35,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,
@@ -169,7 +168,6 @@ homeThing:
     mode: 3_button
     display_timeout: 0
   media_player_group: media_group_component
-  light_group: light_group_component
   service_group: service_group_component
   sensor_group: sensor_group_component
   switch_group: switch_group_component

--- a/white-homething.yaml
+++ b/white-homething.yaml
@@ -43,7 +43,6 @@ external_components:
       homeassistant_component, 
       homeassistant_switch_group, 
       homeassistant_sensor_group,
-      homeassistant_light_group,
       homeassistant_media_player,
       homeassistant_service_group,
       media_player_source,
@@ -104,6 +103,10 @@ homeThing:
   screens:
     - name: Desk Screen
       entities:
+        # - id: cover_megadesk
+        #   type: cover
+        - type: number
+          id: desk_height_number
         - type: command
           name: "desk nudge up"
           command:
@@ -138,6 +141,15 @@ spi:
   clk_pin: GPIO18
   mosi_pin: GPIO19
 
+number:
+  - platform: homeassistant_component
+    entity_id: number.desk_height_cm
+    name: desk height
+    id: desk_height_number
+    min_value: 61.0
+    max_value: 105.0
+    step: 1
+
 display:
   - platform: st7789v
     model: TTGO_TDisplay_135x240
@@ -150,32 +162,3 @@ display:
     lambda: |-
       id(homeThingMenu)->draw_menu_screen();
       return;
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: IP Address
-      internal: True
-      id: wifi_ip
-    ssid:
-      name: SSID
-      internal: True
-      id: wifi_ssid
-
-sensor:
-  - platform: wifi_signal # Reports the WiFi signal strength/RSSI in dB
-    name: "WiFi Signal dB"
-    id: wifi_signal_db
-    update_interval: 60s
-    entity_category: "diagnostic"
-    internal: True
-
-  - platform: copy # Reports the WiFi signal strength in %
-    source_id: wifi_signal_db
-    name: "WiFi Signal %"
-    id: wifi_signal_percent
-    internal: True
-    filters:
-      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
-    unit_of_measurement: "Signal %"
-    entity_category: "diagnostic"


### PR DESCRIPTION
refactored light detail a bit so it can be extended for other components
added input number, helps me a lot with my desk
select an input number to edit
```
external_components:
  - source: github://landonr/homeThing@lando/generic-detail
    refresh: 0s
    components: [homeThing]
  - source:
      type: git
      url: https://github.com/landonr/esphome-components
    refresh: 0s
    components: [
      homeassistant_component
    ]
```


```
number:
  - platform: homeassistant_component
    entity_id: number.desk_height_cm
    name: desk height
    id: desk_height_number
    min_value: 61.0
    max_value: 105.0
    step: 1
```

put on screen
```
...
  screens:
    - name: Desk Screen
      entities:
        - type: number
          id: desk_height_number
```