### PR TITLE
Add custom commands to now playing menu

### DIFF
--- a/common/debugging.yaml
+++ b/common/debugging.yaml
@@ -1,0 +1,18 @@
+debug:
+  update_interval: 5s
+
+text_sensor:
+  - platform: debug
+    device:
+      name: "${friendly_name} Device Info"
+    reset_reason:
+      name: "${friendly_name} Reset Reason"
+
+sensor:
+  - platform: debug
+    free:
+      name: "${friendly_name} Heap Free"
+    block:
+      name: "${friendly_name} Heap Max Block"
+    loop_time:
+      name: "${friendly_name} Loop Time"

--- a/common/device_base.yaml
+++ b/common/device_base.yaml
@@ -1,5 +1,5 @@
 logger:
-  level: INFO
+  level: WARN
 
 ota:
 
@@ -29,10 +29,4 @@ sensor:
   # Uptime sensor.
   - platform: uptime
     name: "${friendly_name} Uptime"
-    update_interval: 10s
-  - platform: template
-    name: "${friendly_name} Free Memory"
-    lambda: return heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
-    unit_of_measurement: 'B'
-    state_class: measurement
     update_interval: 10s

--- a/common/fonts-light.yaml
+++ b/common/fonts-light.yaml
@@ -1,0 +1,21 @@
+substitutions:
+  large_heavy_font_size: "24"
+  large_font_size: "24"
+  medium_font_size: "15"
+  small_font_size: "14"
+
+font:
+    - file: "fonts/iosevka.ttf"
+      id: large_font
+      size: $large_font_size
+      glyphs: '^…*/|\$#<>!?"%()[]+=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz&êÊîÎâÂôÔéÉíÍáÁóÓčëËüÜïÏöÖøØṣṢñãõÑÃÕ''’'
+
+    - file: "fonts/iosevka.ttf"
+      id: medium_font
+      size: $medium_font_size
+      glyphs: '^…*/|\$#<>!?"%()[]+=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz&êÊîÎâÂôÔéÉíÍáÁóÓčëËüÜïÏöÖøØṣṢñãõÑÃÕ''’'
+
+    - file: "fonts/iosevka.ttf"
+      id: small_font
+      size: $small_font_size
+      glyphs: '^…*/|\$#<>!?"%()[]+=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz&êÊîÎâÂôÔéÉíÍáÁóÓčëËüÜïÏöÖøØṣṢñãõÑÃÕ''’'

--- a/components/homeThing/__init__.py
+++ b/components/homeThing/__init__.py
@@ -1,9 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import display, font, color, binary_sensor, sensor, switch, light, text_sensor, number, cover
+from esphome.components import display, font, color, binary_sensor, sensor, switch, light, text_sensor, number, cover, time
 from esphome.components.light import LightState
-from esphome.const import  CONF_ID, CONF_TRIGGER_ID, CONF_MODE, CONF_RED, CONF_BLUE, CONF_GREEN, CONF_NAME, CONF_TYPE
+from esphome.const import  CONF_ID, CONF_TRIGGER_ID, CONF_MODE, CONF_RED, CONF_BLUE, CONF_GREEN, CONF_NAME, CONF_TYPE, CONF_TIME_ID
 from esphome.components.homeassistant_media_player import homeassistant_media_player_ns
 homething_menu_base_ns = cg.esphome_ns.namespace("homething_menu_base")
 
@@ -122,7 +122,7 @@ MENU_DISPLAY_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_TEXT_HELPERS): cv.declare_id(HomeThingMenuTextHelpers),
         cv.GenerateID(CONF_REFACTOR): cv.declare_id(HomeThingMenuRefactor),
         cv.GenerateID(CONF_NOW_PLAYING): cv.declare_id(HomeThingMenuNowPlaying),
-        cv.GenerateID(CONF_HEADER): cv.declare_id(HomeThingMenuHeader),
+        cv.GenerateID(CONF_HEADER): cv.use_id(HomeThingMenuHeader),
     }
 )
 
@@ -225,6 +225,7 @@ DISPLAY_STATE_SCHEMA = cv.Schema(
 HEADER_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(HomeThingMenuHeader),
+        cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
     }
 )
 
@@ -434,6 +435,9 @@ async def menu_display_to_code(config, display_buffer):
     refactor = cg.new_Pvariable(menu_display_conf[CONF_REFACTOR], display_buffer, display_state, text_helpers)
     menu_header = cg.new_Pvariable(menu_display_conf[CONF_HEADER], display_buffer, display_state, text_helpers)
     await ids_to_code(config, menu_header, MENU_HEADER_IDS)
+    if CONF_TIME_ID in config[CONF_HEADER]:
+        time_ = await cg.get_variable(config[CONF_HEADER][CONF_TIME_ID])
+        cg.add(menu_header.set_time_id(time_))
     await battery_to_code(config, menu_header)
     menu_boot = await menu_boot_to_code(config[CONF_BOOT], display_buffer, display_state, menu_header, text_helpers)
     await ids_to_code(config, menu_boot, MENU_BOOT_IDS)

--- a/components/homeThing/__init__.py
+++ b/components/homeThing/__init__.py
@@ -64,6 +64,7 @@ CONF_3_BUTTON = "3_button"
 CONF_2_BUTTON = "2_button"
 CONF_DISPLAY_TIMEOUT = "display_timeout"
 CONF_MENU_ROLLOVER_ON = "menu_rollover"
+CONF_MENU_ROLLBACK_ON = "menu_rollback"
 CONF_SLEEP_SWITCH = "sleep_switch"
 CONF_SLEEP_AFTER = "sleep_after"
 CONF_BACKLIGHT = "backlight"
@@ -147,6 +148,7 @@ MENU_SETTINGS_SCHEMA = cv.Schema(
         cv.Optional(CONF_DISPLAY_TIMEOUT, default=16): cv.int_,
         cv.Optional(CONF_SLEEP_AFTER, default=3600): cv.int_,
         cv.Optional(CONF_MENU_ROLLOVER_ON, default=False): cv.boolean,
+        cv.Optional(CONF_MENU_ROLLBACK_ON, default=False): cv.boolean,
         cv.Optional(CONF_LOCK_AFTER, default=0): cv.int_,
     }
 )
@@ -341,6 +343,7 @@ MENU_SETTING_TYPES = [
     CONF_DISPLAY_TIMEOUT,
     CONF_SLEEP_AFTER,
     CONF_MENU_ROLLOVER_ON,
+    CONF_MENU_ROLLBACK_ON,
     CONF_LOCK_AFTER
 ]
 

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -65,7 +65,7 @@ void HomeThingMenuBase::draw_menu_screen() {
     return;
   }
   menu_drawing_ = true;
-  auto title_name = menu_state_title(activeMenuState).c_str();
+  auto title_name = menu_state_title(activeMenuState);
   if (reload_menu_items_ ||
       (menu_titles.size() == 0 && activeMenuState != bootMenu)) {
     ESP_LOGD(TAG, "draw_menu_screen: reload %d %s #%d", menuIndex,

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -86,7 +86,7 @@ class HomeThingMenuBase : public PollingComponent {
   // controls
 #ifdef USE_MEDIA_PLAYER_GROUP
   bool select_media_player_feature(
-      homeassistant_media_player::MediaPlayerSupportedFeature* feature);
+      homeassistant_media_player::MediaPlayerFeatureCommand* command);
   bool button_press_now_playing_option_continue(
       CircleOptionMenuPosition position);
 #endif

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -76,8 +76,7 @@ class HomeThingMenuBase : public PollingComponent {
   bool selectMenu();
   bool selectMenuHold();
   bool selectRootMenu();
-  std::shared_ptr<MenuTitleBase> menuTitleForType(MenuStates stringType,
-                                                  int index);
+  MenuTitleBase* menuTitleForType(MenuStates stringType, int index);
   void lockDevice();
   void idleTick();
   bool buttonPressWakeUpDisplay();
@@ -164,8 +163,8 @@ class HomeThingMenuBase : public PollingComponent {
 #endif
   HomeThingMenuSettings* menu_settings_{nullptr};
   HomeThingMenuDisplay* menu_display_{nullptr};
-  std::vector<std::shared_ptr<MenuTitleBase>> menuTypesToTitles(
-      std::vector<MenuStates> menu);
+  void menuTypesToTitles(std::vector<MenuStates> menu,
+                         std::vector<MenuTitleBase*>* menu_titles);
   HomeThingMenuAnimation* animation_ = new HomeThingMenuAnimation();
   std::vector<HomeThingMenuScreen*> menu_screens_;
   HomeThingMenuScreen* active_menu_screen{nullptr};
@@ -181,7 +180,7 @@ class HomeThingMenuBase : public PollingComponent {
   void update_display() { this->on_redraw_callbacks_.call(); }
   void debounceUpdateDisplay();
   void update();
-  std::vector<std::shared_ptr<MenuTitleBase>> activeMenu();
+  void activeMenu(std::vector<MenuTitleBase*>*);
   std::vector<MenuStates> rootMenuTitles();
   void reset_menu() {
     menuIndex = 0;
@@ -209,7 +208,7 @@ class HomeThingMenuBase : public PollingComponent {
   int rotary_ = 0;
   int menuIndex = 0;
   int rotaryPosition = 0;
-  std::vector<std::shared_ptr<MenuTitleBase>> menu_titles;
+  std::vector<MenuTitleBase*> menu_titles;
   CallbackManager<void()> on_redraw_callbacks_{};
   const char* const TAG = "homething.menu.base";
   bool menu_drawing_ = false;

--- a/components/homeThing/homeThingMenuDisplay.cpp
+++ b/components/homeThing/homeThingMenuDisplay.cpp
@@ -75,8 +75,8 @@ void HomeThingMenuDisplay::draw_lock_screen(int unlock_presses) {
 }
 
 bool HomeThingMenuDisplay::draw_menu_titles(
-    const std::vector<std::shared_ptr<MenuTitleBase>>* menuTitles,
-    int menuIndex, bool editing_menu_item) {
+    const std::vector<MenuTitleBase*>* menuTitles, int menuIndex,
+    bool editing_menu_item) {
   if (menuTitles->size() == 0 || menuTitles->size() < menuIndex) {
     return false;
   }
@@ -115,8 +115,7 @@ bool HomeThingMenuDisplay::draw_menu_titles(
         break;
       case LightMenuTitleType: {
 #ifdef USE_LIGHT
-        auto lightTitle =
-            std::static_pointer_cast<MenuTitleLight>((*menuTitles)[i]);
+        auto lightTitle = static_cast<MenuTitleLight*>((*menuTitles)[i]);
         if (lightTitle != NULL) {
           animating = draw_menu_title(menuState, i, titleName, yPos,
                                       lightTitle->indentLine());
@@ -130,8 +129,7 @@ bool HomeThingMenuDisplay::draw_menu_titles(
         break;
       }
       case ToggleMenuTitleType: {
-        auto toggleTitle =
-            std::static_pointer_cast<MenuTitleToggle>((*menuTitles)[i]);
+        auto toggleTitle = static_cast<MenuTitleToggle*>((*menuTitles)[i]);
         if (toggleTitle != NULL) {
           animating = draw_menu_title(menuState, i, titleName, yPos,
                                       toggleTitle->indentLine());
@@ -145,7 +143,7 @@ bool HomeThingMenuDisplay::draw_menu_titles(
       }
       case SliderMenuTitleType: {
 #ifdef USE_LIGHT
-        auto item = std::static_pointer_cast<MenuTitleSlider>((*menuTitles)[i]);
+        auto item = static_cast<MenuTitleSlider*>((*menuTitles)[i]);
         SliderSelectionState sliderState =
             menuState == i && editing_menu_item ? SliderSelectionStateActive
             : menuState == i                    ? SliderSelectionStateHover
@@ -161,8 +159,7 @@ bool HomeThingMenuDisplay::draw_menu_titles(
       }
       case PlayerMenuTitleType: {
 #ifdef USE_MEDIA_PLAYER_GROUP
-        auto playerTitle =
-            std::static_pointer_cast<MenuTitlePlayer>((*menuTitles)[i]);
+        auto playerTitle = static_cast<MenuTitlePlayer*>((*menuTitles)[i]);
         if (playerTitle != NULL) {
           draw_menu_title(menuState, i, titleName, yPos,
                           playerTitle->indentLine());
@@ -186,8 +183,7 @@ bool HomeThingMenuDisplay::draw_menu_titles(
 }
 
 bool HomeThingMenuDisplay::draw_menu_screen(
-    MenuStates* activeMenuState,
-    const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu,
+    MenuStates* activeMenuState, const std::vector<MenuTitleBase*>* active_menu,
     const int menuIndex, HomeThingOptionMenu* option_menu,
     bool editing_menu_item) {
   bool boot_complete = boot_->boot_complete();
@@ -262,9 +258,9 @@ int HomeThingMenuDisplay::maxItems() {
   return maxItems;
 }
 
-void HomeThingMenuDisplay::drawLeftTitleIcon(
-    int menuTitleSize, std::shared_ptr<MenuTitleToggle> toggleTitle, int i,
-    int menuState, int yPos) {
+void HomeThingMenuDisplay::drawLeftTitleIcon(int menuTitleSize,
+                                             const MenuTitleToggle* toggleTitle,
+                                             int i, int menuState, int yPos) {
   switch (toggleTitle->leftIconState) {
     case NoMenuTitleLeftIcon:
       break;
@@ -272,8 +268,7 @@ void HomeThingMenuDisplay::drawLeftTitleIcon(
     case OnMenuTitleLeftIcon:
       if (toggleTitle->titleType == LightMenuTitleType) {
 #ifdef USE_LIGHT
-        auto lightToggleTitle =
-            std::static_pointer_cast<MenuTitleLight>(toggleTitle);
+        auto lightToggleTitle = static_cast<const MenuTitleLight*>(toggleTitle);
         if (lightToggleTitle != NULL) {
           auto lightColor =
               lightToggleTitle->leftIconState == OnMenuTitleLeftIcon

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -48,11 +48,10 @@ class HomeThingMenuDisplay {
         header_(header) {}
   void setup();
   void draw_lock_screen(int unlock_presses);
-  bool draw_menu_screen(
-      MenuStates* activeMenuState,
-      const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu,
-      const int menuIndex, HomeThingOptionMenu* option_menu,
-      bool editing_menu_item);
+  bool draw_menu_screen(MenuStates* activeMenuState,
+                        const std::vector<MenuTitleBase*>* active_menu,
+                        const int menuIndex, HomeThingOptionMenu* option_menu,
+                        bool editing_menu_item);
   void updateDisplay(bool force);
 
   void set_animation(HomeThingMenuAnimation* animation) {
@@ -84,17 +83,15 @@ class HomeThingMenuDisplay {
 
  private:
   int scrollTop = 0;
-  bool draw_menu_titles(
-      const std::vector<std::shared_ptr<MenuTitleBase>>* menuTitles,
-      const int menuIndex, bool editing_menu_item);
+  bool draw_menu_titles(const std::vector<MenuTitleBase*>* menuTitles,
+                        const int menuIndex, bool editing_menu_item);
   bool draw_menu_title(int menuState, int i, std::string title, int yPos,
                        bool buttonSpace);
   void drawScrollBar(int menuTitlesCount, int headerHeight, int menuIndex);
   void scrollMenuPosition(int menuIndex);
   int maxItems();
-  void drawLeftTitleIcon(int menuTitleSize,
-                         std::shared_ptr<MenuTitleToggle> toggleTitle, int i,
-                         int menuState, int yPos);
+  void drawLeftTitleIcon(int menuTitleSize, const MenuTitleToggle* toggleTitle,
+                         int i, int menuState, int yPos);
   void drawRightTitleIcon(int menuTitleSize, MenuTitleRightIcon iconState,
                           int i, int menuState, int yPos);
 

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -59,6 +59,12 @@ class HomeThingMenuDisplay {
     animation_ = animation;
     boot_->set_animation(animation);
   }
+  bool get_draw_now_playing_menu() {
+#ifdef USE_MEDIA_PLAYER_GROUP
+    return display_state_->get_draw_now_playing_bottom_menu();
+#endif
+    return false;
+  }
 
 #ifdef USE_MEDIA_PLAYER_GROUP
   void set_media_player_group(

--- a/components/homeThing/homeThingMenuHeader.cpp
+++ b/components/homeThing/homeThingMenuHeader.cpp
@@ -242,7 +242,8 @@ int HomeThingMenuHeader::drawHeaderTime(int oldXPos, int yPosOffset) {
 }
 
 int HomeThingMenuHeader::drawBattery(int oldXPos, int yPosOffset) {
-  if (!display_state_->get_draw_battery_level()) {
+  if (!display_state_->get_draw_battery_level() ||
+      battery_percent_ == nullptr) {
     return oldXPos;
   }
   float batteryWidth = 24;

--- a/components/homeThing/homeThingMenuHeader.cpp
+++ b/components/homeThing/homeThingMenuHeader.cpp
@@ -219,12 +219,15 @@ int HomeThingMenuHeader::drawHeaderVolumeLevel(int oldXPos, int yPosOffset) {
 #endif
 
 int HomeThingMenuHeader::drawHeaderTime(int oldXPos, int yPosOffset) {
-  if (!display_state_->get_draw_header_time() || !esp_time_->is_valid()) {
+  if (esp_time_ == nullptr) {
+    return oldXPos;
+  }
+  if (!display_state_->get_draw_header_time() || !esp_time_->now().is_valid()) {
     return oldXPos;
   }
 
   int yPos = getHeaderTextYPos(yPosOffset);
-  std::string timeString = esp_time_->strftime("%I:%M%P");
+  std::string timeString = esp_time_->now().strftime("%I:%M%P");
   if (timeString.length() > 0 && timeString[0] == '0') {
     timeString.erase(0, 1);
   }

--- a/components/homeThing/homeThingMenuHeader.cpp
+++ b/components/homeThing/homeThingMenuHeader.cpp
@@ -219,21 +219,12 @@ int HomeThingMenuHeader::drawHeaderVolumeLevel(int oldXPos, int yPosOffset) {
 #endif
 
 int HomeThingMenuHeader::drawHeaderTime(int oldXPos, int yPosOffset) {
-  if (!display_state_->get_draw_header_time() || !esp_time_->now().is_valid()) {
+  if (!display_state_->get_draw_header_time() || !esp_time_->is_valid()) {
     return oldXPos;
   }
-  // switch (activeMenuState) {
-  //   case rootMenu:
-  //   case nowPlayingMenu:
-  //     break;
-  //   default:
-  //     if (display_buffer_->get_width() < 200) {
-  //       return oldXPos;
-  //     }
-  //     break;
-  // }
+
   int yPos = getHeaderTextYPos(yPosOffset);
-  std::string timeString = esp_time_->now().strftime("%I:%M%P");
+  std::string timeString = esp_time_->strftime("%I:%M%P");
   if (timeString.length() > 0 && timeString[0] == '0') {
     timeString.erase(0, 1);
   }

--- a/components/homeThing/homeThingMenuHeader.h
+++ b/components/homeThing/homeThingMenuHeader.h
@@ -13,6 +13,7 @@
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/time.h"
 
 namespace esphome {
 namespace homething_menu_base {
@@ -84,7 +85,7 @@ class HomeThingMenuHeader {
   HomeThingMenuTextHelpers* text_helpers_{nullptr};
   sensor::Sensor* battery_percent_{nullptr};
   binary_sensor::BinarySensor* charging_{nullptr};
-  time::RealTimeClock* esp_time_{nullptr};
+  ESPTime* esp_time_{nullptr};
   const char* const TAG = "homething.menu.header";
   HomeThingMenuScreen** active_menu_screen_{nullptr};
 };

--- a/components/homeThing/homeThingMenuHeader.h
+++ b/components/homeThing/homeThingMenuHeader.h
@@ -13,6 +13,7 @@
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/time.h"
 
 namespace esphome {
@@ -36,6 +37,7 @@ class HomeThingMenuHeader {
   void set_active_menu_screen(HomeThingMenuScreen** active_menu_screen) {
     active_menu_screen_ = active_menu_screen;
   }
+  void set_time_id(time::RealTimeClock* time_id) { this->esp_time_ = time_id; }
 
 #ifdef USE_MEDIA_PLAYER_GROUP
   void set_media_player_group(
@@ -85,7 +87,7 @@ class HomeThingMenuHeader {
   HomeThingMenuTextHelpers* text_helpers_{nullptr};
   sensor::Sensor* battery_percent_{nullptr};
   binary_sensor::BinarySensor* charging_{nullptr};
-  ESPTime* esp_time_{nullptr};
+  time::RealTimeClock* esp_time_{nullptr};
   const char* const TAG = "homething.menu.header";
   HomeThingMenuScreen** active_menu_screen_{nullptr};
 };

--- a/components/homeThing/homeThingMenuNowPlaying.cpp
+++ b/components/homeThing/homeThingMenuNowPlaying.cpp
@@ -53,7 +53,16 @@ void HomeThingMenuNowPlaying::drawCircleOptionMenu(
     auto coordinate = get_coordinate(radius, angle);
 
     auto title = feature.command->get_title();
-
+    if (element ==
+        homeassistant_media_player::MediaPlayerSupportedFeature::POWER_SET) {
+      if (media_player_group_->active_player_->playerState ==
+          homeassistant_media_player::RemotePlayerState::
+              PowerOffRemotePlayerState) {
+        title = "Turn On";
+      } else {
+        title = "Turn Off";
+      }
+    }
     display::TextAlign text_alignment =
         text_align_for_circle_position(feature.position);
     if (feature.position == CENTER) {
@@ -72,8 +81,7 @@ void HomeThingMenuNowPlaying::drawCircleOptionMenu(
 }
 
 void HomeThingMenuNowPlaying::drawNowPlayingSelectMenu(
-    const std::vector<std::shared_ptr<MenuTitleBase>>* menu_titles,
-    int menu_index) {
+    const std::vector<MenuTitleBase*>* menu_titles, int menu_index) {
   int yPos = display_buffer_->get_height() - display_state_->get_margin_size() -
              display_state_->get_font_large()->get_baseline();
   auto menuTitlesSize = menu_titles->size();
@@ -119,7 +127,7 @@ void HomeThingMenuNowPlaying::drawNowPlayingSelectMenu(
 
 void HomeThingMenuNowPlaying::drawNowPlaying(
     int menuIndex, HomeThingOptionMenu* option_menu,
-    const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu) {
+    const std::vector<MenuTitleBase*>* active_menu) {
   if ((option_menu && drawOptionMenuAndStop(option_menu)) ||
       display_state_ == nullptr) {
     return;

--- a/components/homeThing/homeThingMenuNowPlaying.cpp
+++ b/components/homeThing/homeThingMenuNowPlaying.cpp
@@ -48,11 +48,11 @@ void HomeThingMenuNowPlaying::drawCircleOptionMenu(
                           display_state_->get_color_palette()->get_gray());
 
   for (auto& feature : supported_features) {
-    auto element = feature.feature;
+    auto element = feature.command->get_feature();
     double angle = feature.position * M_PI / 2.0;
     auto coordinate = get_coordinate(radius, angle);
 
-    auto title = homeassistant_media_player::supported_feature_string(element);
+    auto title = feature.command->get_title();
 
     display::TextAlign text_alignment =
         text_align_for_circle_position(feature.position);
@@ -280,33 +280,6 @@ void HomeThingMenuNowPlaying::drawMediaDuration() {
       text_helpers_->primaryTextColor(display_state_->get_dark_mode()),
       display::TextAlign::TOP_RIGHT, "%d:%s", mediaDuration / 60,
       mediaDurationSeconds.c_str());
-}
-
-std::string HomeThingMenuNowPlaying::stringForNowPlayingMenuState(
-    NowPlayingMenuState state) {
-  switch (state) {
-    case pauseNowPlayingMenuState:
-      return media_player_group_->playTitleString();
-    case volumeUpNowPlayingMenuState:
-      return "Vol Up";
-    case volumeDownNowPlayingMenuState:
-      return "Vol Down";
-    case nextNowPlayingMenuState:
-      return "Next";
-    case menuNowPlayingMenuState:
-      return "Menu";
-    case backNowPlayingMenuState:
-      return "Back";
-    case TVPowerNowPlayingMenuState:
-      return "Power";
-    case homeNowPlayingMenuState:
-      return "TV Home";
-    case groupNowPlayingMenuState:
-      return "Group";
-    case shuffleNowPlayingMenuState:
-      return media_player_group_->shuffle_string();
-  }
-  return "";
 }
 
 void HomeThingMenuNowPlaying::drawVolumeOptionMenu() {

--- a/components/homeThing/homeThingMenuNowPlaying.cpp
+++ b/components/homeThing/homeThingMenuNowPlaying.cpp
@@ -349,7 +349,7 @@ bool HomeThingMenuNowPlaying::drawOptionMenuAndStop(
           getWrappedTitles(display_buffer_->get_width() / 2,
                            display_state_->get_font_large()->get_baseline(),
                            display::TextAlign::TOP_CENTER,
-                           media_player_group_->playingNewSourceText);
+                           media_player_group_->new_source_name());
       drawTextWrapped(
           display_buffer_->get_width() / 2,
           display_state_->get_header_height() +

--- a/components/homeThing/homeThingMenuNowPlaying.h
+++ b/components/homeThing/homeThingMenuNowPlaying.h
@@ -45,7 +45,6 @@ class HomeThingMenuNowPlaying {
   std::string secondsToString(int seconds);
   void drawMediaDuration();
   bool drawOptionMenuAndStop(const HomeThingOptionMenu* option_menu);
-  std::string stringForNowPlayingMenuState(NowPlayingMenuState state);
   void drawNowPlayingSelectMenu(
       const std::vector<std::shared_ptr<MenuTitleBase>>* menu_titles,
       int menu_index);

--- a/components/homeThing/homeThingMenuNowPlaying.h
+++ b/components/homeThing/homeThingMenuNowPlaying.h
@@ -23,9 +23,8 @@ class HomeThingMenuNowPlaying {
         display_state_(new_display_state),
         text_helpers_(new_text_helpers) {}
   PositionCoordinate get_coordinate(double radius, double angle);
-  void drawNowPlaying(
-      int menuIndex, HomeThingOptionMenu* option_menu,
-      const std::vector<std::shared_ptr<MenuTitleBase>>* active_menu);
+  void drawNowPlaying(int menuIndex, HomeThingOptionMenu* option_menu,
+                      const std::vector<MenuTitleBase*>* active_menu);
 
   void set_media_player_group(
       homeassistant_media_player::HomeAssistantMediaPlayerGroup*
@@ -45,9 +44,8 @@ class HomeThingMenuNowPlaying {
   std::string secondsToString(int seconds);
   void drawMediaDuration();
   bool drawOptionMenuAndStop(const HomeThingOptionMenu* option_menu);
-  void drawNowPlayingSelectMenu(
-      const std::vector<std::shared_ptr<MenuTitleBase>>* menu_titles,
-      int menu_index);
+  void drawNowPlayingSelectMenu(const std::vector<MenuTitleBase*>* menu_titles,
+                                int menu_index);
   std::vector<std::string>* getWrappedTitles(int xPos, int fontSize,
                                              display::TextAlign alignment,
                                              std::string text);

--- a/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
+++ b/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
@@ -36,26 +36,14 @@ HomeThingMenuNowPlayingOptionMenu::get_supported_feature_options(
     if (i - i_offset >= max_index) {
       return out;
     }
+    ESP_LOGI(TAG, "get_supported_feature_options: %s index %d of %d, state: %d",
+             player->get_name().c_str(), i, max_index, player->playerState);
     auto command = (supported_features[i]);
     auto feature = command->get_feature();
     ESP_LOGI(
         TAG, "get_supported_feature_options: %s index %d of %d, state: %d - %s",
         player->get_name().c_str(), i, max_index, player->playerState,
         homeassistant_media_player::supported_feature_string(feature).c_str());
-    if (feature == homeassistant_media_player::TURN_ON &&
-        player->playerState > homeassistant_media_player::RemotePlayerState::
-                                  PowerOffRemotePlayerState) {
-      i_offset++;
-      max_index++;
-      continue;
-    } else if (feature == homeassistant_media_player::TURN_OFF &&
-               player->playerState <=
-                   homeassistant_media_player::RemotePlayerState::
-                       PowerOffRemotePlayerState) {
-      i_offset++;
-      max_index++;
-      continue;
-    }
     auto newItem = CircleOptionMenuItem();
     newItem.position = static_cast<CircleOptionMenuPosition>(i - i_offset);
     newItem.command = command;

--- a/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
+++ b/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
@@ -60,7 +60,8 @@ HomeThingMenuNowPlayingOptionMenu::tap_option_menu(
   if (supported_features.size() > position) {
     ESP_LOGD(TAG, "tap_option_menu: %d - %s", static_cast<int>(position),
              homeassistant_media_player::supported_feature_string(
-                 supported_features[static_cast<int>(position)].feature)
+                 supported_features[static_cast<int>(position)]
+                     .command->get_feature())
                  .c_str());
     return supported_features[static_cast<int>(position)].command;
   }

--- a/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
+++ b/components/homeThing/homeThingMenuNowPlayingOptionMenu.cpp
@@ -28,7 +28,7 @@ void HomeThingMenuNowPlayingOptionMenu::set_active_menu(
 std::vector<CircleOptionMenuItem>
 HomeThingMenuNowPlayingOptionMenu::get_supported_feature_options(
     homeassistant_media_player::HomeAssistantBaseMediaPlayer* player) {
-  auto supported_features = player->get_option_menu_features();
+  auto supported_features = *(player->get_option_menu_features(bottomMenu_));
   auto out = std::vector<CircleOptionMenuItem>();
   auto max_index = std::min(static_cast<int>(supported_features.size()), 5);
   int i_offset = 0;
@@ -36,8 +36,9 @@ HomeThingMenuNowPlayingOptionMenu::get_supported_feature_options(
     if (i - i_offset >= max_index) {
       return out;
     }
-    auto feature = *(supported_features[i].get());
-    ESP_LOGD(
+    auto command = (supported_features[i]);
+    auto feature = command->get_feature();
+    ESP_LOGI(
         TAG, "get_supported_feature_options: %s index %d of %d, state: %d - %s",
         player->get_name().c_str(), i, max_index, player->playerState,
         homeassistant_media_player::supported_feature_string(feature).c_str());
@@ -57,13 +58,13 @@ HomeThingMenuNowPlayingOptionMenu::get_supported_feature_options(
     }
     auto newItem = CircleOptionMenuItem();
     newItem.position = static_cast<CircleOptionMenuPosition>(i - i_offset);
-    newItem.feature = feature;
+    newItem.command = command;
     out.push_back(newItem);
   }
   return out;
 }
 
-homeassistant_media_player::MediaPlayerSupportedFeature*
+homeassistant_media_player::MediaPlayerFeatureCommand*
 HomeThingMenuNowPlayingOptionMenu::tap_option_menu(
     CircleOptionMenuPosition position,
     homeassistant_media_player::HomeAssistantBaseMediaPlayer* player) {
@@ -73,7 +74,7 @@ HomeThingMenuNowPlayingOptionMenu::tap_option_menu(
              homeassistant_media_player::supported_feature_string(
                  supported_features[static_cast<int>(position)].feature)
                  .c_str());
-    return &supported_features[static_cast<int>(position)].feature;
+    return supported_features[static_cast<int>(position)].command;
   }
   return nullptr;
 }

--- a/components/homeThing/homeThingMenuNowPlayingOptionMenu.h
+++ b/components/homeThing/homeThingMenuNowPlayingOptionMenu.h
@@ -17,7 +17,7 @@ namespace homething_menu_base {
 
 class HomeThingMenuNowPlayingOptionMenu {
  public:
-  homeassistant_media_player::MediaPlayerSupportedFeature* tap_option_menu(
+  homeassistant_media_player::MediaPlayerFeatureCommand* tap_option_menu(
       CircleOptionMenuPosition position,
       homeassistant_media_player::HomeAssistantBaseMediaPlayer* player);
   void set_active_menu(
@@ -25,6 +25,7 @@ class HomeThingMenuNowPlayingOptionMenu {
       homeassistant_media_player::HomeAssistantBaseMediaPlayer* player);
   HomeThingOptionMenu* get_active_menu() { return active_menu_; }
   void clear_active_menu() { active_menu_ = nullptr; }
+  void set_bottom_menu(bool bottomMenu) { bottomMenu_ = bottomMenu; }
 
  private:
   HomeThingOptionMenu* active_menu_{nullptr};
@@ -32,6 +33,7 @@ class HomeThingMenuNowPlayingOptionMenu {
   std::vector<CircleOptionMenuItem> get_supported_feature_options(
       homeassistant_media_player::HomeAssistantBaseMediaPlayer* player);
   const char* const TAG = "homething.menu.option";
+  bool bottomMenu_ = false;
 };
 }  // namespace homething_menu_base
 }  // namespace esphome

--- a/components/homeThing/homeThingMenuRefactor.cpp
+++ b/components/homeThing/homeThingMenuRefactor.cpp
@@ -43,9 +43,11 @@ void HomeThingMenuRefactor::drawLightSliderRGBBar(int xPos, int yPos,
   }
 }
 
-void HomeThingMenuRefactor::drawLightSliderBar(
-    int xPos, int yPos, int sliderHeight, SliderSelectionState sliderState,
-    std::shared_ptr<MenuTitleSlider> slider, bool drawRGB) {
+void HomeThingMenuRefactor::drawLightSliderBar(int xPos, int yPos,
+                                               int sliderHeight,
+                                               SliderSelectionState sliderState,
+                                               const MenuTitleSlider* slider,
+                                               bool drawRGB) {
   int slider_min = xPos + display_state_->get_slider_margin_size();
   int slider_width = display_buffer_->get_width() -
                      2 * display_state_->get_slider_margin_size();
@@ -75,7 +77,7 @@ void HomeThingMenuRefactor::drawLightSliderBar(
 
 void HomeThingMenuRefactor::drawLightSliderCircle(
     int xPos, int yPos, int sliderHeight, SliderSelectionState sliderState,
-    std::shared_ptr<MenuTitleSlider> slider, bool drawRGB) {
+    const MenuTitleSlider* slider, bool drawRGB) {
   int circleSize = 5;
   int slider_width = display_buffer_->get_width() -
                      2 * display_state_->get_slider_margin_size();
@@ -117,7 +119,7 @@ void HomeThingMenuRefactor::drawLightSliderCircle(
 
 void HomeThingMenuRefactor::drawLightSliderTitle(
     int xPos, int yPos, int sliderHeight, SliderSelectionState sliderState,
-    std::shared_ptr<MenuTitleSlider> slider, bool drawRGB) {
+    const MenuTitleSlider* slider, bool drawRGB) {
   std::string sliderTitle = "";
   if (drawRGB) {
     sliderTitle = slider->get_name();
@@ -152,9 +154,10 @@ void HomeThingMenuRefactor::drawLightSliderTitle(
   }
 }
 
-void HomeThingMenuRefactor::drawLightSlider(
-    int xPos, int yPos, SliderSelectionState sliderState,
-    std::shared_ptr<MenuTitleSlider> slider, bool drawRGB) {
+void HomeThingMenuRefactor::drawLightSlider(int xPos, int yPos,
+                                            SliderSelectionState sliderState,
+                                            const MenuTitleSlider* slider,
+                                            bool drawRGB) {
   int sliderHeight = 3;
   if (sliderState == SliderSelectionStateHover) {
     display_buffer_->filled_rectangle(

--- a/components/homeThing/homeThingMenuRefactor.h
+++ b/components/homeThing/homeThingMenuRefactor.h
@@ -24,22 +24,19 @@ class HomeThingMenuRefactor {
   void drawGroupedBar(int yPos, bool extend);
   void drawLightSliderBar(int xPos, int yPos, int sliderHeight,
                           SliderSelectionState sliderState,
-                          std::shared_ptr<MenuTitleSlider> slider,
-                          bool drawRGB);
+                          const MenuTitleSlider* slider, bool drawRGB);
   void drawLightSliderRGBBar(int xPos, int yPos, int sliderHeight,
                              int slider_width);
   void drawLightSlider(int xPos, int yPos, SliderSelectionState sliderState,
-                       std::shared_ptr<MenuTitleSlider> slider, bool drawRGB);
+                       const MenuTitleSlider* slider, bool drawRGB);
   void drawLightSwitch(bool switchState, int yPos, Color lightColor,
                        bool rowSelected);
   void drawLightSliderCircle(int xPos, int yPos, int sliderHeight,
                              SliderSelectionState sliderState,
-                             std::shared_ptr<MenuTitleSlider> slider,
-                             bool drawRGB);
+                             const MenuTitleSlider* slider, bool drawRGB);
   void drawLightSliderTitle(int xPos, int yPos, int sliderHeight,
                             SliderSelectionState sliderState,
-                            std::shared_ptr<MenuTitleSlider> slider,
-                            bool drawRGB);
+                            const MenuTitleSlider* slider, bool drawRGB);
   void drawSwitch(bool switchState, int yPos);
   void drawArrow(int yPos, int menuTitlesCount, int maxItems);
 

--- a/components/homeThing/homeThingMenuScreen.cpp
+++ b/components/homeThing/homeThingMenuScreen.cpp
@@ -3,15 +3,15 @@
 namespace esphome {
 namespace homething_menu_base {
 
-std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
-  std::vector<std::shared_ptr<MenuTitleBase>> out;
-  out.push_back(std::make_shared<MenuTitleBase>(this->get_name(), "",
-                                                NoMenuTitleRightIcon));
+void HomeThingMenuScreen::menu_titles(
+    std::vector<MenuTitleBase*>* menu_titles) {
+  menu_titles->push_back(
+      new MenuTitleBase(this->get_name(), "", NoMenuTitleRightIcon));
 #ifdef SHOW_VERSION
   if (show_version_) {
     auto versionString = COMPONENTS_HOMETHING_VERSION;
-    out.push_back(std::make_shared<MenuTitleBase>(versionString, "",
-                                                  NoMenuTitleRightIcon));
+    menu_titles->push_back(
+        new MenuTitleBase(versionString, "", NoMenuTitleRightIcon));
   }
 #endif
 
@@ -20,7 +20,7 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
       case MenuItemTypeNone:
         break;
       case MenuItemTypeTitle:
-        out.push_back(std::make_shared<MenuTitleBase>(
+        menu_titles->push_back(new MenuTitleBase(
             std::get<1>(entity)->get_name(), "", NoMenuTitleRightIcon));
         break;
       case MenuItemTypeSwitch: {
@@ -29,7 +29,7 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
         ESP_LOGD(TAG, "switch state %d", switchObject->state);
         MenuTitleLeftIcon state =
             switchObject->state ? OnMenuTitleLeftIcon : OffMenuTitleLeftIcon;
-        out.push_back(std::make_shared<MenuTitleToggle>(
+        menu_titles->push_back(new MenuTitleToggle(
             switchObject->get_name(), switchObject->get_object_id(), state,
             NoMenuTitleRightIcon));
 #endif
@@ -42,7 +42,7 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
         MenuTitleLeftIcon state = coverObject->is_fully_closed()
                                       ? OffMenuTitleLeftIcon
                                       : OnMenuTitleLeftIcon;
-        out.push_back(std::make_shared<MenuTitleToggle>(
+        menu_titles->push_back(new MenuTitleToggle(
             coverObject->get_name(), coverObject->get_object_id(), state,
             NoMenuTitleRightIcon));
 #endif
@@ -54,12 +54,12 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
             static_cast<text_sensor::TextSensor*>(std::get<1>(entity));
         ESP_LOGD(TAG, "text sensor state %s", textSensor->state.c_str());
         if (textSensor->get_name() != "") {
-          out.push_back(std::make_shared<MenuTitleBase>(
+          menu_titles->push_back(new MenuTitleBase(
               textSensor->get_name() + " " + textSensor->get_state(), "",
               NoMenuTitleRightIcon));
         } else {
-          out.push_back(std::make_shared<MenuTitleBase>(textSensor->state, "",
-                                                        NoMenuTitleRightIcon));
+          menu_titles->push_back(
+              new MenuTitleBase(textSensor->state, "", NoMenuTitleRightIcon));
         }
 #endif
         break;
@@ -67,11 +67,11 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
       case MenuItemTypeCommand: {
         auto command = static_cast<MenuCommand*>(std::get<1>(entity));
         if (command->get_name() != "") {
-          out.push_back(std::make_shared<MenuTitleBase>(command->get_name(), "",
-                                                        NoMenuTitleRightIcon));
+          menu_titles->push_back(
+              new MenuTitleBase(command->get_name(), "", NoMenuTitleRightIcon));
         } else {
-          out.push_back(std::make_shared<MenuTitleBase>(
-              command->get_object_id(), "", NoMenuTitleRightIcon));
+          menu_titles->push_back(new MenuTitleBase(command->get_object_id(), "",
+                                                   NoMenuTitleRightIcon));
         }
         break;
       }
@@ -80,12 +80,12 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
         auto sensor = static_cast<sensor::Sensor*>(std::get<1>(entity));
         auto state = to_string(static_cast<int>(sensor->get_state())).c_str();
         if (sensor->get_name() != "") {
-          out.push_back(std::make_shared<MenuTitleBase>(
+          menu_titles->push_back(new MenuTitleBase(
               sensor->get_name() + ": " + state, "", NoMenuTitleRightIcon));
         } else {
-          out.push_back(std::make_shared<MenuTitleBase>(
-              sensor->get_object_id() + ": " + state, "",
-              NoMenuTitleRightIcon));
+          menu_titles->push_back(
+              new MenuTitleBase(sensor->get_object_id() + ": " + state, "",
+                                NoMenuTitleRightIcon));
         }
 #endif
         break;
@@ -99,9 +99,9 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
         MenuTitleRightIcon rightIcon = supportsBrightness(light)
                                            ? ArrowMenuTitleRightIcon
                                            : NoMenuTitleRightIcon;
-        out.push_back(std::make_shared<MenuTitleLight>(
-            light->get_name(), "", state, rightIcon,
-            light::rgbLightColor(light)));
+        menu_titles->push_back(new MenuTitleLight(light->get_name(), "", state,
+                                                  rightIcon,
+                                                  light::rgbLightColor(light)));
 #endif
         break;
       }
@@ -110,19 +110,18 @@ std::vector<std::shared_ptr<MenuTitleBase>> HomeThingMenuScreen::menu_titles() {
         auto number = static_cast<number::Number*>(std::get<1>(entity));
         auto state = to_string(number->state).c_str();
         if (number->get_name() != "") {
-          out.push_back(std::make_shared<MenuTitleBase>(
+          menu_titles->push_back(new MenuTitleBase(
               number->get_name() + ": " + state, "", NoMenuTitleRightIcon));
         } else {
-          out.push_back(std::make_shared<MenuTitleBase>(
-              number->get_object_id() + ": " + state, "",
-              NoMenuTitleRightIcon));
+          menu_titles->push_back(
+              new MenuTitleBase(number->get_object_id() + ": " + state, "",
+                                NoMenuTitleRightIcon));
         }
 #endif
         break;
       }
     }
   }
-  return out;
 }
 
 bool HomeThingMenuScreen::select_menu(int index) {

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -137,7 +137,7 @@ class HomeThingMenuScreen {
   void add_on_state_callback(std::function<void()>&& callback) {
     this->callback_.add(std::move(callback));
   }
-  std::vector<std::shared_ptr<MenuTitleBase>> menu_titles();
+  void menu_titles(std::vector<MenuTitleBase*>* menu_titles);
   bool select_menu(int index);
   bool select_menu_hold(int index);
   const std::tuple<MenuItemType, EntityBase*>* get_menu_item(int index);

--- a/components/homeThing/homeThingMenuSettings.h
+++ b/components/homeThing/homeThingMenuSettings.h
@@ -36,11 +36,15 @@ class HomeThingMenuSettings {
   bool get_menu_rollover() { return menu_rollover_; }
   void set_menu_rollover(bool menu_rollover) { menu_rollover_ = menu_rollover; }
 
+  bool get_menu_rollback() { return menu_rollback_; }
+  void set_menu_rollback(bool menu_rollback) { menu_rollback_ = menu_rollback; }
+
  private:
   MenuMode mode_;
   int display_timeout_;
   int sleep_after_;
   bool menu_rollover_;
+  bool menu_rollback_;
 
 #ifdef USE_SWITCH
   switch_::Switch* sleep_switch_;

--- a/components/homeThing/homeThingMenuTitle.h
+++ b/components/homeThing/homeThingMenuTitle.h
@@ -270,7 +270,7 @@ static void mediaPlayersTitleString(
         MENU_TITLE_TAG,
         "mediaPlayersTitleString: player %s parent set %d group members %d",
         media_player->get_entity_id().c_str(), parent != NULL,
-        groupMembers.size());
+        groupMembers->size());
     if (parent != NULL) {
       // ignore parent if its a soundbar because the tv is the root parent
       if (parent->mediaSource ==

--- a/components/homeThing/homeThingMenuTitle.h
+++ b/components/homeThing/homeThingMenuTitle.h
@@ -457,23 +457,6 @@ static std::vector<std::shared_ptr<MenuTitleBase>> speakerNowPlayingMenuStates(
                                                       NoMenuTitleRightIcon));
         break;
       }
-      case homeassistant_media_player::MediaPlayerSupportedFeature::VOLUME_SET:
-        if (bottomMenu) {
-          out.push_back(std::make_shared<MenuTitleBase>(
-              "Vol Up",
-              homeassistant_media_player::supported_feature_string_map
-                  [homeassistant_media_player::MediaPlayerSupportedFeature::
-                       VOLUME_UP],
-              NoMenuTitleRightIcon));
-          out.push_back(std::make_shared<MenuTitleBase>(
-              "Vol Dn",
-              homeassistant_media_player::supported_feature_string_map
-                  [homeassistant_media_player::MediaPlayerSupportedFeature::
-                       VOLUME_DOWN],
-              NoMenuTitleRightIcon));
-          break;
-        }
-        break;
       case homeassistant_media_player::MediaPlayerSupportedFeature::
           SHUFFLE_SET: {
         std::string shuffle_string =

--- a/components/homeThing/homeThingOptionMenu.h
+++ b/components/homeThing/homeThingOptionMenu.h
@@ -21,7 +21,7 @@ enum CircleOptionMenuPosition : int {
 struct CircleOptionMenuItem {
   CircleOptionMenuPosition position;
 #ifdef USE_MEDIA_PLAYER_GROUP
-  homeassistant_media_player::MediaPlayerSupportedFeature feature;
+  homeassistant_media_player::MediaPlayerFeatureCommand* command;
 #endif
 };
 

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -28,20 +28,20 @@ external_components:
       url: https://github.com/ssieb/custom_components
     components: [ ip5306 ]
   - source:
-    #   type: git
-    #   url: https://github.com/landonr/homeThing
-    #   ref: main
-    # refresh: 0s
-      type: local
-      path: components
+      type: git
+      url: https://github.com/landonr/homeThing
+      ref: main
+    refresh: 0s
+      # type: local
+      # path: components
     components: [homeThing]
   - source:
-    #   type: git
-    #   url: https://github.com/landonr/esphome-components
-    #   ref: main
-    # refresh: 0s
-      type: local
-      path: ../local_components/components
+      type: git
+      url: https://github.com/landonr/esphome-components
+      ref: main
+    refresh: 0s
+      # type: local
+      # path: ../local_components/components
     components: [
       homeassistant_component,
       homeassistant_media_player,

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -36,12 +36,12 @@ external_components:
       path: components
     components: [homeThing]
   - source:
-      type: git
-      url: https://github.com/landonr/esphome-components
-      ref: main
-    refresh: 0s
-      # type: local
-      # path: ../local_components/components
+    #   type: git
+    #   url: https://github.com/landonr/esphome-components
+    #   ref: main
+    # refresh: 0s
+      type: local
+      path: ../local_components/components
     components: [
       homeassistant_component,
       homeassistant_media_player,

--- a/fireremote.yaml
+++ b/fireremote.yaml
@@ -28,12 +28,12 @@ external_components:
       url: https://github.com/ssieb/custom_components
     components: [ ip5306 ]
   - source:
-      type: git
-      url: https://github.com/landonr/homeThing
-      ref: main
-    refresh: 0s
-      # type: local
-      # path: components
+    #   type: git
+    #   url: https://github.com/landonr/homeThing
+    #   ref: main
+    # refresh: 0s
+      type: local
+      path: components
     components: [homeThing]
   - source:
       type: git

--- a/homeConfig/media_player.yaml
+++ b/homeConfig/media_player.yaml
@@ -114,9 +114,9 @@ homeassistant_media_player:
   media_players:
     - id: media_player_beam
       type: speaker
-    - id: media_player_office
-      type: speaker
     - id: media_player_kitchen
+      type: speaker
+    - id: media_player_office
       type: speaker
     - id: media_player_bedroom
       type: speaker

--- a/homeConfig/media_player.yaml
+++ b/homeConfig/media_player.yaml
@@ -44,6 +44,11 @@ media_player:
         type: spotify
       - id: fav_playlists
         type: custom
+    commands:
+      name: "group all"
+      command:
+        - homeassistant.service:
+            service: script.sonos_group_all
   - platform: homeassistant_media_player
     name: Kitchen
     entity_id: "media_player.kitchen"
@@ -65,6 +70,16 @@ media_player:
       - id: spotty
         type: spotify
   - platform: homeassistant_media_player
+    name: Bedroom
+    entity_id: "media_player.bedroom"
+    id: media_player_bedroom
+    type: speaker
+    sources:
+      - id: sonos
+        type: sonos
+      - id: spotty
+        type: spotify
+  - platform: homeassistant_media_player
     name: TV
     entity_id: "media_player.55_tcl_roku_tv"
     id: media_player_tv
@@ -74,19 +89,19 @@ media_player:
     sources:
       - id: youtube_videos
         type: custom
-  - platform: homeassistant_media_player
-    name: Spotify
-    entity_id: "media_player.spotify_landorghini"
-    id: media_player_spotify
-    type: speaker
-    sources:
-      - id: spotty
-        type: spotify
-  - platform: homeassistant_media_player
-    name: PC
-    entity_id: "media_player.tower"
-    id: media_player_tower
-    type: speaker
+  # - platform: homeassistant_media_player
+  #   name: Spotify
+  #   entity_id: "media_player.spotify_landorghini"
+  #   id: media_player_spotify
+  #   type: speaker
+  #   sources:
+  #     - id: spotty
+  #       type: spotify
+  # - platform: homeassistant_media_player
+  #   name: PC
+  #   entity_id: "media_player.tower"
+  #   id: media_player_tower
+  #   type: speaker
   # - platform: homeassistant_media_player
   #   name: Kodi
   #   entity_id: "media_player.kodi_desktop"
@@ -100,13 +115,15 @@ homeassistant_media_player:
       type: speaker
     - id: media_player_office
       type: speaker
-    - id: media_player_tv
-      type: roku
     - id: media_player_kitchen
       type: speaker
-    - id: media_player_spotify
+    - id: media_player_bedroom
       type: speaker
-    - id: media_player_tower
-      type: speaker
+    - id: media_player_tv
+      type: roku
+    # - id: media_player_spotify
+    #   type: speaker
+    # - id: media_player_tower
+    #   type: speaker
     # - id: media_player_kodi
     #   type: kodi

--- a/homeConfig/media_player.yaml
+++ b/homeConfig/media_player.yaml
@@ -1,5 +1,6 @@
 media_player_source_sonos:
   id: sonos
+  limit: 50
 
 media_player_source_spotify:
   id: spotty

--- a/white-homething.yaml
+++ b/white-homething.yaml
@@ -19,7 +19,7 @@ wifi:
   password: !secret wifi_password
   fast_connect: true
   id: wifi_id
-  # power_save_mode: HIGH
+  power_save_mode: HIGH
 
 external_components:
   - source:
@@ -48,7 +48,7 @@ external_components:
 
 packages:
   device_base: !include common/device_base.yaml
-  settings: !include common/settings.yaml
+  # settings: !include common/settings.yaml
   ipod_control_backlight: !include common/ipod/lilygo_tdisplay_ipod_backlight.yaml
   ipod_control_battery: !include common/ipod/lilygo_tdisplay_ipod_battery.yaml
   ipod_control_binary_sensor: !include common/ipod/lilygo_tdisplay_ipod_binary_sensor.yaml
@@ -56,8 +56,9 @@ packages:
   ipod_control_sleep: !include common/ipod/lilygo_tdisplay_ipod_sleep.yaml
   home_media_player: !include homeConfig/media_player.yaml
   home_switch: !include homeConfig/switch.yaml
-  fonts: !include common/fonts.yaml
+  fonts: !include common/fonts-light.yaml
   icon_fonts: !include common/icon_fonts.yaml
+  debug: !include common/debugging.yaml
 
 substitutions:
   friendly_name: "white homething"
@@ -103,7 +104,7 @@ homeThing:
     font_small: small_font
     font_medium: medium_font
     font_large: large_font
-    font_large_heavy: large_heavy_font
+    font_large_heavy: large_font
     font_material_large: material_font_large
     font_material_small: material_font_small
     font_logo: home_thing_logo
@@ -153,19 +154,19 @@ homeThing:
           command:
             - homeassistant.service:
                 service: script.off_script
-    - name: Settings Screen
-      show_version: True
-      entities:
-        - id: backlight
-          type: light
-        - id: "restart_switch"
-          type: switch
-        - id: wifi_ssid
-          type: text_sensor
-        - id: wifi_signal_percent
-          type: sensor
-        - id: wifi_ip
-          type: text_sensor
+    # - name: Settings Screen
+    #   show_version: True
+    #   entities:
+    #     - id: backlight
+    #       type: light
+    #     - id: "restart_switch"
+    #       type: switch
+    #     - id: wifi_ssid
+    #       type: text_sensor
+    #     - id: wifi_signal_percent
+    #       type: sensor
+    #     - id: wifi_ip
+    #       type: text_sensor
 
 spi:
   clk_pin: GPIO18

--- a/white-homething.yaml
+++ b/white-homething.yaml
@@ -19,10 +19,7 @@ wifi:
   password: !secret wifi_password
   fast_connect: true
   id: wifi_id
-  power_save_mode: HIGH
-  ap:
-    ssid: "${friendly_name} Fallback"
-    password: !secret wifi_fallback_password
+  # power_save_mode: HIGH
 
 external_components:
   - source:

--- a/white-homething.yaml
+++ b/white-homething.yaml
@@ -89,6 +89,8 @@ homeThing:
     sleep_after: 14400
   sleep_switch: sleep_toggle
   backlight: backlight
+  header:
+    time_id: esptime
   battery:
     battery_percent: battery_percent
     charging: charging
@@ -113,8 +115,6 @@ homeThing:
       entities:
         - type: cover
           id: cover_megadesk
-        - type: number
-          id: desk_height_number
         - type: command
           name: "desk nudge up"
           command:
@@ -171,15 +171,6 @@ homeThing:
 spi:
   clk_pin: GPIO18
   mosi_pin: GPIO19
-
-number:
-  - platform: homeassistant_component
-    entity_id: number.desk_height_cm
-    name: desk height
-    id: desk_height_number
-    min_value: 61.0
-    max_value: 105.0
-    step: 1
 
 display:
   - platform: st7789v


### PR DESCRIPTION
uses https://github.com/landonr/esphome-components/pull/3

```
media_player:
  - platform: homeassistant_media_player
    name: Beam
    entity_id: "media_player.beam"
    id: media_player_beam
    type: speaker
    sources:
      - id: sonos
        type: sonos
      - id: spotty
        type: spotify
      - id: fav_playlists
        type: custom
    commands:
      name: "group all"
      command:
        - homeassistant.service:
            service: script.sonos_group_all
```
this lets me group all my speakers in one button. It can be used to call any esphome / home assistant service

also 
 - added a limit to sonos sources because it takes up a lot of memory when its at the max (100)
 - included a light fonts yaml for low memory devices
 - cleaned up some memory leaks
   - removed usage of shared_ptr and manually deleted everything
   - all the vectors are passed by pointer now