### PR TITLE
add automations for notifications

### DIFF
--- a/common/voice_assistant.yaml
+++ b/common/voice_assistant.yaml
@@ -20,29 +20,22 @@ voice_assistant:
   on_start:
     then:
       - homething_menu.clear_notifications: homeThingMenu
-      - homething_menu.add_notification: homeThingMenu
+      - homething_menu.add_notification:
           title: "Voice Assistant"
-          message: "Listening"
-          icon: ""
-          persistent: false
+          subtitle: "Listening"
   on_error:
     then:
-      - homething_menu.add_notification: homeThingMenu
+      - homething_menu.add_notification: 
           title: "Voice Assistant"
           subtitle: "Error"
-          message: x
+          message:  |-
+            return x;
           persistent: true
   on_stt_end:
     then:
-      - homething_menu.add_notification: homeThingMenu
+      - homething_menu.add_notification: 
           title: "Voice Assistant"
           subtitle: "Understood"
-          message: x
+          message: |-
+            return x;
           persistent: true
-  on_tts_start:
-    then:
-      - homething_menu.add_notification: homeThingMenu
-          title: "Voice Assistant"
-          subtitle: "Speaking"
-          message: x
-          persistent: false

--- a/common/voice_assistant.yaml
+++ b/common/voice_assistant.yaml
@@ -19,22 +19,30 @@ voice_assistant:
   microphone: external_mic
   on_start:
     then:
-      lambda: |-
-        id(homeThingMenu)->clearNotifications();
-        id(homeThingMenu)->addNotification("Voice Assistant", "Listening", "", true);
-        return;
+      - homething_menu.clear_notifications: homeThingMenu
+      - homething_menu.add_notification: homeThingMenu
+          title: "Voice Assistant"
+          message: "Listening"
+          icon: ""
+          persistent: false
   on_error:
     then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Error", message, false);
-        return;
+      - homething_menu.add_notification: homeThingMenu
+          title: "Voice Assistant"
+          subtitle: "Error"
+          message: x
+          persistent: true
   on_stt_end:
     then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Understood", x, false);
-        return;
+      - homething_menu.add_notification: homeThingMenu
+          title: "Voice Assistant"
+          subtitle: "Understood"
+          message: x
+          persistent: true
   on_tts_start:
     then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Finished", x, true);
-        return;
+      - homething_menu.add_notification: homeThingMenu
+          title: "Voice Assistant"
+          subtitle: "Speaking"
+          message: x
+          persistent: false

--- a/components/homeThing/__init__.py
+++ b/components/homeThing/__init__.py
@@ -1,25 +1,28 @@
 import esphome.codegen as cg
+from esphome import automation
 import esphome.config_validation as cv
 from esphome.components import display, binary_sensor, sensor, switch, light, text_sensor, number, cover, time, button, image
 from esphome.components.light import LightState
 from esphome.const import  CONF_ID, CONF_TRIGGER_ID, CONF_MODE, CONF_NAME, CONF_TYPE, CONF_TIME_ID
 from esphome.components.homeThingDisplayState import homething_display_state_ns
 # from esphome.components.homeThingApp import homething_app_ns
-homething_menu_base_ns = cg.esphome_ns.namespace("homething_menu_base")
 
-HomeThingMenuBase = homething_menu_base_ns.class_("HomeThingMenuBase", cg.PollingComponent)
-HomeThingMenuScreen = homething_menu_base_ns.class_("HomeThingMenuScreen")
-MenuCommand = homething_menu_base_ns.class_("MenuCommand")
-HomeThingMenuBoot = homething_menu_base_ns.class_("HomeThingMenuBoot")
-HomeThingMenuSettings = homething_menu_base_ns.class_("HomeThingMenuSettings")
-HomeThingMenuAnimation = homething_menu_base_ns.class_("HomeThingMenuAnimation")
-HomeThingMenuDisplay = homething_menu_base_ns.class_("HomeThingMenuDisplay")
-HomeThingMenuHeader = homething_menu_base_ns.class_("HomeThingMenuHeader")
-HomeThingMenuRefactor = homething_menu_base_ns.class_("HomeThingMenuRefactor")
+from .automation import *
 
-HomeThingMenuBaseConstPtr = HomeThingMenuBase.operator("ptr").operator("const")
-
-homething_app_ns = cg.esphome_ns.namespace("homething_menu_app")
+from .types import (
+    homething_menu_base_ns,
+    HomeThingMenuBaseConstPtr,
+    homething_app_ns,
+    HomeThingMenuBase,
+    HomeThingMenuScreen,
+    MenuCommand,
+    HomeThingMenuBoot,
+    HomeThingMenuSettings,
+    HomeThingMenuDisplay,
+    HomeThingMenuHeader,
+    HomeThingMenuRefactor,
+    HomeThingDisplayMenuOnRedrawTrigger
+)
 
 AUTO_LOAD = ["sensor"]
 DEPENDENCIES = ["wifi", "api", "homeThingDisplayState"]
@@ -75,81 +78,6 @@ CONF_MEDIA_PLAYERS_LOADED = "media_players_loaded"
 CONF_DISPLAY_TIMEOUT_WHILE_CHARGING = "display_timeout_while_charging"
 CONF_IDLE_APP = "idle_app"
 CONF_MAX_BRIGHTNESS = "max_brightness"
-# Automation
-
-from esphome import automation
-from esphome.automation import maybe_simple_id
-HomeThingDisplayMenuOnRedrawTrigger = homething_menu_base_ns.class_("HomeThingDisplayMenuOnRedrawTrigger", automation.Trigger)
-
-UpAction = homething_menu_base_ns.class_("UpAction", automation.Action)
-DownAction = homething_menu_base_ns.class_("DownAction", automation.Action)
-LeftAction = homething_menu_base_ns.class_("LeftAction", automation.Action)
-RightAction = homething_menu_base_ns.class_("RightAction", automation.Action)
-SelectAction = homething_menu_base_ns.class_("SelectAction", automation.Action)
-ScrollClockwiseAction = homething_menu_base_ns.class_("ScrollClockwiseAction", automation.Action)
-ScrollCounterClockwiseAction = homething_menu_base_ns.class_("ScrollCounterClockwiseAction", automation.Action)
-
-BackAction = homething_menu_base_ns.class_("BackAction", automation.Action)
-OptionAction = homething_menu_base_ns.class_("OptionAction", automation.Action)
-HomeAction = homething_menu_base_ns.class_("HomeAction", automation.Action)
-
-MENU_ACTION_SCHEMA = maybe_simple_id(
-    {
-        cv.GenerateID(CONF_ID): cv.use_id(HomeThingMenuBase),
-    }
-)
-
-@automation.register_action("homething_menu.up", UpAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.down", DownAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.left", LeftAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.right", RightAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.select", SelectAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.scroll_clockwise", ScrollClockwiseAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.scroll_counter_clockwise", ScrollCounterClockwiseAction, MENU_ACTION_SCHEMA)
-
-@automation.register_action("homething_menu.back", BackAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.option", OptionAction, MENU_ACTION_SCHEMA)
-@automation.register_action("homething_menu.home", HomeAction, MENU_ACTION_SCHEMA)
-
-async def menu_up_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_down_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_left_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_right_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_select_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_scroll_clockwise_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_scroll_counter_clockwise_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_back_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_option_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
-
-async def menu_home_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, paren)
 
 # Menu
 

--- a/components/homeThing/automation.h
+++ b/components/homeThing/automation.h
@@ -135,7 +135,10 @@ class AddNotificationAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(std::string, message)
   TEMPLATABLE_VALUE(bool, persistent)
 
-  void play(Ts... x) override { this->menu_->addNotification(title_.value(x...), subtitle_.value(x...), message_.value(x...), persistent_.value(x...)); }
+  void play(Ts... x) override {
+    this->menu_->addNotification(title_.value(x...), subtitle_.value(x...),
+                                 message_.value(x...), persistent_.value(x...));
+  }
 
  protected:
   HomeThingMenuBase* menu_;

--- a/components/homeThing/automation.h
+++ b/components/homeThing/automation.h
@@ -124,5 +124,32 @@ class ServiceCalledTrigger : public Trigger<> {
     parent->add_on_command_callback([this, parent]() { trigger(); });
   }
 };
+
+template <typename... Ts>
+class AddNotificationAction : public Action<Ts...> {
+ public:
+  explicit AddNotificationAction(HomeThingMenuBase* menu) : menu_(menu) {}
+
+  TEMPLATABLE_VALUE(std::string, title)
+  TEMPLATABLE_VALUE(std::string, subtitle)
+  TEMPLATABLE_VALUE(std::string, message)
+  TEMPLATABLE_VALUE(bool, persistent)
+
+  void play(Ts... x) override { this->menu_->addNotification(title_.value(x...), subtitle_.value(x...), message_.value(x...), persistent_.value(x...)); }
+
+ protected:
+  HomeThingMenuBase* menu_;
+};
+
+template <typename... Ts>
+class ClearNotificationsAction : public Action<Ts...> {
+ public:
+  explicit ClearNotificationsAction(HomeThingMenuBase* menu) : menu_(menu) {}
+
+  void play(Ts... x) override { this->menu_->clearNotifications(); }
+
+ protected:
+  HomeThingMenuBase* menu_;
+};
 }  // namespace homething_menu_base
 }  // namespace esphome

--- a/components/homeThing/automation.md
+++ b/components/homeThing/automation.md
@@ -1,0 +1,121 @@
+# homeThing Actions
+
+## Menu Actions
+
+### homething_menu.up Action
+Go up in the menu, or up on a TV
+
+```yaml
+on_...
+  then:
+    - homething_menu.up: homeThingMenu
+```
+
+### homething_menu.down Action
+Play/Pause media player, or go down on a TV
+
+```yaml
+on_...
+  then:
+    - homething_menu.down: homeThingMenu
+```
+
+### homething_menu.left Action
+Previous track on media player, or go left on a TV
+
+```yaml
+on_...
+  then:
+    - homething_menu.left: homeThingMenu
+```
+
+### homething_menu.right Action
+Next track on media player, or go right on a TV
+
+```yaml
+on_...
+  then:
+    - homething_menu.right: homeThingMenu
+```
+
+### homething_menu.select Action
+Select the current menu item
+
+```yaml
+on_...
+  then:
+    - homething_menu.select: homeThingMenu
+```
+
+### homething_menu.scroll_clockwise Action
+Move the menu cursor down, volume up
+
+```yaml
+on_...
+  then:
+    - homething_menu.scroll_clockwise: homeThingMenu
+```
+
+### homething_menu.scroll_counter_clockwise Action
+Move the menu cursor up, volume down
+
+```yaml
+on_...
+  then:
+    - homething_menu.scroll_counter_clockwise: homeThingMenu
+```
+
+### homething_menu.back Action
+Go back in the menu
+
+```yaml
+on_...
+  then:
+    - homething_menu.back: homeThingMenu
+```
+
+### homething_menu.option Action
+Open the options menu
+
+```yaml
+on_...
+  then:
+    - homething_menu.option: homeThingMenu
+```
+
+### homething_menu.home Action
+Go to the home screen
+
+```yaml
+on_...
+  then:
+    - homething_menu.home: homeThingMenu
+```
+
+## Notification Actions
+
+### homething_menu.clear_notifications Action
+Clears any existing notifications from homething_menu.
+
+```yaml
+on_...
+  then:
+    - homething_menu.clear_notifications: homeThingMenu
+```
+
+### homething_menu.add_notification Action
+Adds a new notification
+- **Title**: Text shown in notification header
+- **Subtitle**: Text shown at the top of the content of notification
+- **Message**: Text shown in content of notification
+- **Persistent**: Notification stays on screen after screen lock (Optional: default false, set to true for a persistent notification)
+
+```yaml
+on_...
+  then:
+    - homething_menu.add_notification: 
+        title: "Notification Title"
+        subtitle: "Notification Subtitle"
+        message: "Notification Message
+        persistent: true
+```

--- a/components/homeThing/automation.py
+++ b/components/homeThing/automation.py
@@ -88,8 +88,8 @@ ADD_NOTIFICATION_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ID): cv.use_id(HomeThingMenuBase),
         cv.Required(CONF_TITLE): cv.templatable(cv.string),
-        cv.Required(CONF_SUBTITLE): cv.templatable(cv.string),
-        cv.Optional(CONF_MESSAGE, default="123"): cv.templatable(cv.string),
+        cv.Optional(CONF_SUBTITLE, default=""): cv.templatable(cv.string),
+        cv.Optional(CONF_MESSAGE, default=""): cv.templatable(cv.string),
         cv.Optional(CONF_PERSISTENT, default=False): cv.boolean,
     }
 )

--- a/components/homeThing/automation.py
+++ b/components/homeThing/automation.py
@@ -1,0 +1,118 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.automation import maybe_simple_id
+from esphome.const import CONF_ID
+
+from .types import (
+    HomeThingMenuBase,
+    UpAction,
+    DownAction,
+    LeftAction,
+    RightAction,
+    SelectAction,
+    ScrollClockwiseAction,
+    ScrollCounterClockwiseAction,
+    BackAction,
+    OptionAction,
+    HomeAction,
+    AddNotificationAction,
+    ClearNotificationsAction,
+)
+
+MENU_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(CONF_ID): cv.use_id(HomeThingMenuBase),
+    }
+)
+
+# Menu Button Actions
+@automation.register_action("homething_menu.up", UpAction, MENU_ACTION_SCHEMA)
+async def menu_up_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.down", DownAction, MENU_ACTION_SCHEMA)
+async def menu_down_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.left", LeftAction, MENU_ACTION_SCHEMA)
+async def menu_left_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.right", RightAction, MENU_ACTION_SCHEMA)
+async def menu_right_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.select", SelectAction, MENU_ACTION_SCHEMA)
+async def menu_select_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.scroll_clockwise", ScrollClockwiseAction, MENU_ACTION_SCHEMA)
+async def menu_scroll_clockwise_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.scroll_counter_clockwise", ScrollCounterClockwiseAction, MENU_ACTION_SCHEMA)
+async def menu_scroll_counter_clockwise_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+# Menu Navigation Actions
+@automation.register_action("homething_menu.back", BackAction, MENU_ACTION_SCHEMA)
+async def menu_back_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.option", OptionAction, MENU_ACTION_SCHEMA)
+async def menu_option_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+@automation.register_action("homething_menu.home", HomeAction, MENU_ACTION_SCHEMA)
+async def menu_home_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+# Notification Actions
+CONF_TITLE = "title"
+CONF_SUBTITLE = "subtitle"
+CONF_MESSAGE = "message"
+CONF_PERSISTENT = "persistent"
+
+ADD_NOTIFICATION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.use_id(HomeThingMenuBase),
+        cv.Required(CONF_TITLE): cv.templatable(cv.string),
+        cv.Required(CONF_SUBTITLE): cv.templatable(cv.string),
+        cv.Optional(CONF_MESSAGE, default="123"): cv.templatable(cv.string),
+        cv.Optional(CONF_PERSISTENT, default=False): cv.boolean,
+    }
+)
+
+@automation.register_action("homething_menu.add_notification", AddNotificationAction, ADD_NOTIFICATION_SCHEMA)
+async def menu_add_notification_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    if CONF_TITLE in config:
+        templ = await cg.templatable(config[CONF_TITLE], args, cg.std_string)
+        cg.add(var.set_title(templ))
+    if CONF_SUBTITLE in config:
+        templ = await cg.templatable(config[CONF_SUBTITLE], args, cg.std_string)
+        cg.add(var.set_subtitle(templ))
+    if CONF_MESSAGE in config:
+        templ = await cg.templatable(config[CONF_MESSAGE], args, cg.std_string)
+        cg.add(var.set_message(templ))
+    if CONF_PERSISTENT in config:
+        cg.add(var.set_persistent(config[CONF_PERSISTENT]))
+
+    return var
+
+@automation.register_action("homething_menu.clear_notifications", ClearNotificationsAction, MENU_ACTION_SCHEMA)
+async def menu_clear_notifications_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)

--- a/components/homeThing/homeThingMenuBase.cpp
+++ b/components/homeThing/homeThingMenuBase.cpp
@@ -438,10 +438,10 @@ bool HomeThingMenuBase::skipBootPressed() {
 
 void HomeThingMenuBase::addNotification(const std::string& title,
                                         const std::string& subtitle,
-                                        const std::string& text,
-                                        bool autoClear) {
+                                        const std::string& message,
+                                        bool persistent) {
   if (notifications_) {
-    notifications_->addNotification(title, subtitle, text, autoClear);
+    notifications_->addNotification(title, subtitle, message, persistent);
     ESP_LOGD(TAG, "addNotification: add notification %s", title.c_str());
   } else {
     ESP_LOGD(TAG, "addNotification: no notifications");
@@ -451,11 +451,10 @@ void HomeThingMenuBase::addNotification(const std::string& title,
   }
 }
 
-bool HomeThingMenuBase::clearNotifications() {
+void HomeThingMenuBase::clearNotifications() {
   if (notifications_) {
-    return notifications_->clearNotifications();
+    notifications_->clearNotifications();
   }
-  return false;
 }
 
 bool HomeThingMenuBase::buttonPressWakeUpDisplay() {

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -97,9 +97,9 @@ class HomeThingMenuBase : public PollingComponent {
   bool buttonPressUnlock();
 
   void addNotification(const std::string& title, const std::string& subtitle,
-                       const std::string& text, bool autoClear);
+                       const std::string& message, bool persistent);
 
-  bool clearNotifications();
+  void clearNotifications();
 
   // create service for this with input select options
   void goToScreenFromString(std::string screenName);
@@ -124,7 +124,11 @@ class HomeThingMenuBase : public PollingComponent {
         ESP_LOGD(TAG, "button_press_and_continue: reset animation %d",
                  menuTree.front());
         animation_->resetAnimation();
-        return !clearNotifications();
+        if (notifications_ != nullptr && notifications_->notificationCount() > 0) {
+          // clear notifications and redraw
+          clearNotifications();
+          return false;
+        }
       }
     } else {
       return false;

--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -124,7 +124,8 @@ class HomeThingMenuBase : public PollingComponent {
         ESP_LOGD(TAG, "button_press_and_continue: reset animation %d",
                  menuTree.front());
         animation_->resetAnimation();
-        if (notifications_ != nullptr && notifications_->notificationCount() > 0) {
+        if (notifications_ != nullptr &&
+            notifications_->notificationCount() > 0) {
           // clear notifications and redraw
           clearNotifications();
           return false;

--- a/components/homeThing/homeThingMenuNotifications.cpp
+++ b/components/homeThing/homeThingMenuNotifications.cpp
@@ -13,7 +13,7 @@ void HomeThingMenuNotifications::drawNotifications() {
 
     it->time_added_seconds++;  // Increment time_added for each drawn frame
 
-    if (it->autoClear && it->time_added_seconds > MAX_NOTIFICATION_TIME) {
+    if (!it->persistent && it->time_added_seconds > MAX_NOTIFICATION_TIME) {
       it = notifications_.erase(
           it);  // Remove notification if time exceeds limit
     } else {
@@ -77,11 +77,11 @@ int HomeThingMenuNotifications::drawNotification(
         notification.subtitle, maxLines, display_buffer_);
   }
 
-  if (!notification.text.empty()) {
+  if (!notification.message.empty()) {
     display_state_->drawTextWrapped(
         textXPos, textYPos, display_state_->get_font_small(),
         display_state_->primaryTextColor(), display::TextAlign::LEFT,
-        notification.text, maxLines, display_buffer_);
+        notification.message, maxLines, display_buffer_);
   }
 
   return yPos + rectHeight;
@@ -89,26 +89,25 @@ int HomeThingMenuNotifications::drawNotification(
 
 void HomeThingMenuNotifications::addNotification(const std::string& title,
                                                  const std::string& subtitle,
-                                                 const std::string& text,
-                                                 bool autoClear) {
+                                                 const std::string& message,
+                                                 bool persistent) {
 
-  Notification newNotification = {title, subtitle, text, autoClear, 0};
+  Notification newNotification = {title, subtitle, message, persistent, 0};
   notifications_.erase(
       std::remove_if(notifications_.begin(), notifications_.end(),
                      [](const Notification& notification) {
-                       return notification.autoClear;
+                       return !notification.persistent;
                      }),
       notifications_.end());
 
   notifications_.push_back(newNotification);
 }
 
-bool HomeThingMenuNotifications::clearNotifications() {
+void HomeThingMenuNotifications::clearNotifications() {
   if (notifications_.empty()) {
-    return false;
+    return;
   }
   notifications_.clear();
-  return true;
 }
 
 }  // namespace homething_menu_base

--- a/components/homeThing/homeThingMenuNotifications.h
+++ b/components/homeThing/homeThingMenuNotifications.h
@@ -11,8 +11,8 @@ namespace homething_menu_base {
 struct Notification {
   std::string title;
   std::string subtitle;
-  std::string text;
-  bool autoClear;
+  std::string message;
+  bool persistent;
   int time_added_seconds;
 };
 
@@ -26,8 +26,9 @@ class HomeThingMenuNotifications {
   void drawNotifications();
   int drawNotification(const Notification notification, int yPos);
   void addNotification(const std::string& title, const std::string& subtitle,
-                       const std::string& text, bool autoClear);
-  bool clearNotifications();
+                       const std::string& message, bool persistent);
+  void clearNotifications();
+  int notificationCount() { return notifications_.size(); }
   // Add any other necessary functions or members here
 
  private:

--- a/components/homeThing/types.py
+++ b/components/homeThing/types.py
@@ -1,0 +1,39 @@
+import esphome.codegen as cg
+from esphome import automation
+
+# Base
+homething_menu_base_ns = cg.esphome_ns.namespace("homething_menu_base")
+
+HomeThingMenuBase = homething_menu_base_ns.class_("HomeThingMenuBase", cg.PollingComponent)
+HomeThingMenuScreen = homething_menu_base_ns.class_("HomeThingMenuScreen")
+MenuCommand = homething_menu_base_ns.class_("MenuCommand")
+HomeThingMenuBoot = homething_menu_base_ns.class_("HomeThingMenuBoot")
+HomeThingMenuSettings = homething_menu_base_ns.class_("HomeThingMenuSettings")
+HomeThingMenuAnimation = homething_menu_base_ns.class_("HomeThingMenuAnimation")
+HomeThingMenuDisplay = homething_menu_base_ns.class_("HomeThingMenuDisplay")
+HomeThingMenuHeader = homething_menu_base_ns.class_("HomeThingMenuHeader")
+HomeThingMenuRefactor = homething_menu_base_ns.class_("HomeThingMenuRefactor")
+
+HomeThingMenuBaseConstPtr = HomeThingMenuBase.operator("ptr").operator("const")
+
+homething_app_ns = cg.esphome_ns.namespace("homething_menu_app")
+
+# Automation Actions
+
+UpAction = homething_menu_base_ns.class_("UpAction", automation.Action)
+DownAction = homething_menu_base_ns.class_("DownAction", automation.Action)
+LeftAction = homething_menu_base_ns.class_("LeftAction", automation.Action)
+RightAction = homething_menu_base_ns.class_("RightAction", automation.Action)
+SelectAction = homething_menu_base_ns.class_("SelectAction", automation.Action)
+ScrollClockwiseAction = homething_menu_base_ns.class_("ScrollClockwiseAction", automation.Action)
+ScrollCounterClockwiseAction = homething_menu_base_ns.class_("ScrollCounterClockwiseAction", automation.Action)
+
+BackAction = homething_menu_base_ns.class_("BackAction", automation.Action)
+OptionAction = homething_menu_base_ns.class_("OptionAction", automation.Action)
+HomeAction = homething_menu_base_ns.class_("HomeAction", automation.Action)
+
+AddNotificationAction = homething_menu_base_ns.class_("AddNotificationAction", automation.Action)
+ClearNotificationsAction = homething_menu_base_ns.class_("ClearNotificationsAction", automation.Action)
+
+# Triggers
+HomeThingDisplayMenuOnRedrawTrigger = homething_menu_base_ns.class_("HomeThingDisplayMenuOnRedrawTrigger", automation.Trigger)

--- a/components/homeThing/version.h
+++ b/components/homeThing/version.h
@@ -4,8 +4,8 @@
 
 namespace esphome {
 namespace homething_menu_base {
-static const std::string COMPONENTS_HOMETHING_VERSION =
-    "improv-wifi/2024-04-06";
+static const std::string COMPONENTS_HOMETHING_VERSION = "main/2024-04-27";
 }
 }  // namespace esphome
 #endif  // COMPONENTS_HOMETHING_VERSION_H_
+

--- a/components/homeThing/version.h
+++ b/components/homeThing/version.h
@@ -8,4 +8,3 @@ static const std::string COMPONENTS_HOMETHING_VERSION = "main/2024-04-27";
 }
 }  // namespace esphome
 #endif  // COMPONENTS_HOMETHING_VERSION_H_
-

--- a/tdisplay-s3.yaml
+++ b/tdisplay-s3.yaml
@@ -233,25 +233,26 @@ voice_assistant:
   microphone: external_mic
   on_start:
     then:
-      lambda: |-
-        id(homeThingMenu)->clearNotifications();
-        id(homeThingMenu)->addNotification("Voice Assistant", "Listening", "", true);
-        return;
+      - homething_menu.clear_notifications: homeThingMenu
+      - homething_menu.add_notification:
+          title: "Voice Assistant"
+          subtitle: "Listening"
   on_error:
     then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Error", message, false);
-        return;
+      - homething_menu.add_notification: 
+          title: "Voice Assistant"
+          subtitle: "Error"
+          message:  |-
+            return x;
+          persistent: true
   on_stt_end:
     then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Understood", x, false);
-        return;
-  on_tts_start:
-    then:
-      lambda: |-
-        id(homeThingMenu)->addNotification("Voice Assistant", "Finished", x, true);
-        return;
+      - homething_menu.add_notification: 
+          title: "Voice Assistant"
+          subtitle: "Understood"
+          message: |-
+            return x;
+          persistent: true
 
 ### Weather App
 

--- a/tdisplay-s3.yaml
+++ b/tdisplay-s3.yaml
@@ -23,9 +23,10 @@ external_components:
   - source: github://landonr/lilygo-tdisplays3-esphome@v0.1
     components: [tdisplays3]
     refresh: 0s
-  - source: github://landonr/homeThing@main
-      # type: local
-      # path: components
+  - source: github://landonr/homeThing@main@main #update_to_head_ref
+  # - source:      
+  #     type: local
+  #     path: components
     refresh: 0s
     components: [homeThing, homeThingDisplayState, homeThingApp, homeThingAppNowPlaying, homeThingAppSnake, homeThingAppCatToy, homeThingAppBreakout, homeThingAppWeather]
   - source:

--- a/tdisplay-s3.yaml
+++ b/tdisplay-s3.yaml
@@ -23,7 +23,7 @@ external_components:
   - source: github://landonr/lilygo-tdisplays3-esphome@v0.1
     components: [tdisplays3]
     refresh: 0s
-  - source: github://landonr/homeThing@main@main #update_to_head_ref
+  - source: github://landonr/homeThing@main #update_to_head_ref
   # - source:      
   #     type: local
   #     path: components


### PR DESCRIPTION
add types and automation python files

### homething_menu.clear_notifications Action
Clears any existing notifications from homething_menu.

### homething_menu.add_notification Action
Adds a new notification
- **Title**: Text shown in notification header
- **Subtitle**: Text shown at the top of the content of notification
- **Message**: Text shown in content of notification
- **Persistent**: Notification stays on screen after screen lock (Optional: default false, set to true for a persistent notification)

```yaml
...
    then:
      - homething_menu.clear_notifications: homeThingMenu
      - homething_menu.add_notification: 
          title: "Notification Title"
          subtitle: "Notification Subtitle"
          message: "Notification Message
          persistent: true
```