### PR TITLE
Fix compile error for online_image

### DIFF
--- a/common/nowPlayingImage.yaml
+++ b/common/nowPlayingImage.yaml
@@ -30,6 +30,9 @@ substitutions:
   online_image_text_sensor_entity_id: "sensor.media_player_image_proxy_url"
   online_image_display_id: "my_display"
 
+http_request:
+  verify_ssl: false
+
 text_sensor:
   - platform: homeassistant
     id: ${online_image_text_sensor_id}


### PR DESCRIPTION
After updating to the latest esphome I am getting this error:
```
Failed config

http_request: None
  {}
ESPHome supports certificate verification only via ESP-IDF. Set 'verify_ssl: false' to skip certificate validation and allow less secure HTTPS connections
```

This seems to be related to the online_image component.
This change fixes the config error.