### PR TITLE
Fix build against ESPHome 2026.7 API removals

### DIFF
--- a/components/homeThing/homeThingEntityHelpers.h
+++ b/components/homeThing/homeThingEntityHelpers.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include "esphome/core/entity_base.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace homething_menu_base {
+
+inline std::string entity_object_id(const EntityBase* entity) {
+  char buffer[OBJECT_ID_MAX_LEN];
+  size_t length = entity->write_object_id_to(buffer, sizeof(buffer));
+  return std::string(buffer, length);
+}
+
+inline std::string value_accuracy_string(float value,
+                                         int8_t accuracy_decimals) {
+  char buffer[VALUE_ACCURACY_MAX_LEN];
+  size_t length = value_accuracy_to_buf(buffer, value, accuracy_decimals);
+  return std::string(buffer, length);
+}
+
+}  // namespace homething_menu_base
+}  // namespace esphome

--- a/components/homeThing/homeThingMenuScreen.cpp
+++ b/components/homeThing/homeThingMenuScreen.cpp
@@ -1,5 +1,7 @@
 #include "homeThingMenuScreen.h"
 
+#include "esphome/components/homeThing/homeThingEntityHelpers.h"
+
 #ifdef USE_LIGHT
 #include "esphome/components/homeThing/homeThingMenuTitleLight.h"
 #endif
@@ -38,13 +40,13 @@ std::string HomeThingMenuScreen::entity_name_at_index(int index) {
       if (command->get_name() != "") {
         return command->get_name();
       } else {
-        return command->get_object_id();
+        return entity_object_id(command);
       }
     }
     case MenuItemTypeSensor: {
 #ifdef USE_SENSOR
       auto sensor = static_cast<sensor::Sensor*>(std::get<1>(entity));
-      auto name = sensor->get_name() == "" ? sensor->get_object_id()
+      auto name = sensor->get_name() == "" ? entity_object_id(sensor)
                                            : sensor->get_name();
       return name;
 #endif
@@ -53,7 +55,7 @@ std::string HomeThingMenuScreen::entity_name_at_index(int index) {
     case MenuItemTypeNumber: {
 #ifdef USE_NUMBER
       auto number = static_cast<number::Number*>(std::get<1>(entity));
-      auto name = number->get_name() == "" ? number->get_object_id()
+      auto name = number->get_name() == "" ? entity_object_id(number)
                                            : number->get_name();
       return name;
 #endif
@@ -63,7 +65,7 @@ std::string HomeThingMenuScreen::entity_name_at_index(int index) {
 #ifdef USE_FAN
       auto fan = static_cast<fan::Fan*>(std::get<1>(entity));
       auto name =
-          fan->get_name() == "" ? fan->get_object_id() : fan->get_name();
+          fan->get_name() == "" ? entity_object_id(fan) : fan->get_name();
       return name;
 #endif
       break;
@@ -71,7 +73,7 @@ std::string HomeThingMenuScreen::entity_name_at_index(int index) {
     case MenuItemTypeSelect: {
 #ifdef USE_SELECT
       auto select = static_cast<select::Select*>(std::get<1>(entity));
-      auto name = select->get_name() == "" ? select->get_object_id()
+      auto name = select->get_name() == "" ? entity_object_id(select)
                                            : select->get_name();
       return name;
 #endif
@@ -127,7 +129,7 @@ void HomeThingMenuScreen::menu_titles(std::vector<MenuTitleBase*>* menu_titles,
                                       ? OffMenuTitleLeftIcon
                                       : OnMenuTitleLeftIcon;
         menu_titles->push_back(new MenuTitleToggle(
-            title, coverObject->get_object_id(), state, NoMenuTitleRightIcon));
+            title, entity_object_id(coverObject), state, NoMenuTitleRightIcon));
         break;
 #endif
       }
@@ -137,18 +139,20 @@ void HomeThingMenuScreen::menu_titles(std::vector<MenuTitleBase*>* menu_titles,
         ESP_LOGD(TAG, "switch state %d", switchObject->state);
         MenuTitleLeftIcon state =
             switchObject->state ? OnMenuTitleLeftIcon : OffMenuTitleLeftIcon;
-        menu_titles->push_back(new MenuTitleToggle(
-            title, switchObject->get_object_id(), state, NoMenuTitleRightIcon));
+        menu_titles->push_back(
+            new MenuTitleToggle(title, entity_object_id(switchObject), state,
+                                NoMenuTitleRightIcon));
 #endif
         break;
       }
       case MenuItemTypeSensor: {
 #ifdef USE_SENSOR
         auto sensor = static_cast<sensor::Sensor*>(std::get<1>(entity));
-        auto state = value_accuracy_to_string(sensor->get_state(),
-                                              sensor->get_accuracy_decimals());
-        if (sensor->get_unit_of_measurement() != "") {
-          state = state + sensor->get_unit_of_measurement();
+        auto state = value_accuracy_string(sensor->get_state(),
+                                           sensor->get_accuracy_decimals());
+        auto unit = sensor->get_unit_of_measurement_ref();
+        if (!unit.empty()) {
+          state = state + unit.c_str();
         }
         menu_titles->push_back(
             new MenuTitleValue(title, "", NoMenuTitleRightIcon, state));
@@ -159,7 +163,7 @@ void HomeThingMenuScreen::menu_titles(std::vector<MenuTitleBase*>* menu_titles,
       case MenuItemTypeNumber: {
 #ifdef USE_NUMBER
         auto number = static_cast<number::Number*>(std::get<1>(entity));
-        auto state = value_accuracy_to_string(number->state, 0);
+        auto state = value_accuracy_string(number->state, 0);
         auto unit = number->get_unit_of_measurement_ref();
         if (!unit.empty()) {
           state = state + unit.c_str();
@@ -179,11 +183,11 @@ void HomeThingMenuScreen::menu_titles(std::vector<MenuTitleBase*>* menu_titles,
         if (fanObject->state) {
           auto speed = to_string(static_cast<int>(fanObject->speed)) + "%";
           menu_titles->push_back(
-              new MenuTitleToggle(title, fanObject->get_object_id(), speed,
+              new MenuTitleToggle(title, entity_object_id(fanObject), speed,
                                   state, NoMenuTitleRightIcon));
         } else {
           menu_titles->push_back(new MenuTitleToggle(
-              title, fanObject->get_object_id(), state, NoMenuTitleRightIcon));
+              title, entity_object_id(fanObject), state, NoMenuTitleRightIcon));
         }
 #endif
         break;
@@ -193,7 +197,7 @@ void HomeThingMenuScreen::menu_titles(std::vector<MenuTitleBase*>* menu_titles,
         auto select = static_cast<select::Select*>(std::get<1>(entity));
         auto state = select->state;
         menu_titles->push_back(new MenuTitleValue(
-            title, select->get_object_id(), NoMenuTitleRightIcon, state));
+            title, entity_object_id(select), NoMenuTitleRightIcon, state));
 #endif
         break;
       }

--- a/components/homeThing/homeThingMenuTitleLight.h
+++ b/components/homeThing/homeThingMenuTitleLight.h
@@ -3,6 +3,7 @@
 #ifdef USE_LIGHT
 #include <string>
 #include <vector>
+#include "esphome/components/homeThing/homeThingEntityHelpers.h"
 #include "esphome/components/homeThing/homeThingMenuTitleSlider.h"
 #include "esphome/components/homeThing/homeThingMenuTitleToggle.h"
 #include "esphome/components/homeassistant_component/LightExtensions.h"
@@ -54,20 +55,20 @@ static void lightTitleItems(light::LightState* light,
         !is_on ? 0
                : static_cast<int>(light->remote_values.get_brightness() * 255);
     menu_titles->push_back(
-        new MenuTitleSlider("Brightness", "%%", light->get_object_id(), 0,
+        new MenuTitleSlider("Brightness", "%%", entity_object_id(light), 0,
                             MAX_BRIGHTNESS, brightness, 0, 100));
   }
   if (supportsColorTemperature(light)) {
     auto max_mireds = light->get_traits().get_max_mireds();
     auto min_mireds = light->get_traits().get_min_mireds();
     menu_titles->push_back(new MenuTitleSlider(
-        "Temperature", "K", light->get_object_id(), min_mireds, max_mireds,
+        "Temperature", "K", entity_object_id(light), min_mireds, max_mireds,
         light->remote_values.get_color_temperature(), 1000000 / min_mireds,
         1000000 / max_mireds));
   }
   if (supportsColor(light)) {
     menu_titles->push_back(new MenuTitleSlider("Color", "",
-                                               light->get_object_id(), 0, 360,
+                                               entity_object_id(light), 0, 360,
                                                get_hsv_color(light), 0, 360));
   }
   if (light->supports_effects()) {


### PR DESCRIPTION
Follows up #153, which fixed part of the 2026.7 fallout. These removals still break the build.

## Why

The scheduled **Build ESPHome** workflow tracks ESPHome releases, and 2026.7.3 removed APIs the menu components use. #153 handled the light listener interface, `set_effect`, the media player callback and the number unit-of-measurement move. What's left:

| Removed | Replacement |
|---|---|
| `EntityBase::get_object_id()` → `std::string` | `write_object_id_to(char*, size_t)` |
| `value_accuracy_to_string(...)` | `value_accuracy_to_buf(span<char,64>, ...)` |

## Changes

**New `components/homeThing/homeThingEntityHelpers.h`** — two `std::string`-returning wrappers over the buffer-based APIs (`entity_object_id`, `value_accuracy_string`), so call sites keep their existing shape rather than each growing a stack buffer.

- `homeThingMenuScreen.cpp` — 12 × `get_object_id()`, 2 × `value_accuracy_to_string()`
- `homeThingMenuTitleLight.h` — 3 × `get_object_id()`

Also switches the sensor unit read to `get_unit_of_measurement_ref()`, matching what the number branch already does after #153. The plain accessor still compiles but is deprecated for removal in 2026.9.0, so this avoids repeating the exercise in two months.

## Verification

Compiled against esphome 2026.7.3 with the component sourced from the worktree (`type: local`, not `github://`), so the builds exercise this branch's code:

| Config | Result |
|---|---|
| `m5stack-fire` (esp32 arduino) | image created |
| `tdisplay-s3` (esp32s3 esp-idf) | image created |
| `tdisplay-ipod` (esp32) | image created |
| `debug` (esp32) | image created |

`tdisplay-s3` pulls in the app components (`Snake`, `CatToy`, `Breakout`, `Weather`). clang-format 15 lint clean, matching the CI step.

Not built locally: `tdisplay-t4.yaml`, `tdisplay-s3-amoled.yaml`, `basic.yaml` — same component set, and CI covers them since all seven configs carry the `#update_to_head_ref` marker after 58a9532.
