### PR TITLE
Use templated callback registration (ESPHome 2026.4 Callback struct)

### DIFF
--- a/components/homeThing/homeThingMenuBase.h
+++ b/components/homeThing/homeThingMenuBase.h
@@ -105,8 +105,9 @@ class HomeThingMenuBase : public PollingComponent {
   // create service for this with input select options
   void goToScreenFromString(std::string screenName);
   void displayUpdateDebounced();
-  void add_on_redraw_callback(std::function<void()>&& cb) {
-    this->on_redraw_callbacks_.add(std::move(cb));
+  template <typename F>
+  void add_on_redraw_callback(F&& cb) {
+    this->on_redraw_callbacks_.add(std::forward<F>(cb));
   }
 
  private:

--- a/components/homeThing/homeThingMenuBoot.h
+++ b/components/homeThing/homeThingMenuBoot.h
@@ -76,8 +76,9 @@ class HomeThingMenuBoot {
     return get_boot_menu_state() == BOOT_MENU_STATE_COMPLETE;
   }
 
-  void add_on_state_callback(std::function<void()>&& callback) {
-    this->callback_.add(std::move(callback));
+  template <typename F>
+  void add_on_state_callback(F&& callback) {
+    this->callback_.add(std::forward<F>(callback));
   }
 
 #ifdef USE_IMAGE

--- a/components/homeThing/homeThingMenuDisplay.h
+++ b/components/homeThing/homeThingMenuDisplay.h
@@ -71,8 +71,9 @@ class HomeThingMenuDisplay {
   bool boot_complete();
   BootMenuSkipState bootSequenceCanSkip(const MenuStates activeMenuState);
 
-  void add_on_state_callback(std::function<void()>&& callback) {
-    this->callback_.add(std::move(callback));
+  template <typename F>
+  void add_on_state_callback(F&& callback) {
+    this->callback_.add(std::forward<F>(callback));
   }
 
  private:

--- a/components/homeThing/homeThingMenuScreen.h
+++ b/components/homeThing/homeThingMenuScreen.h
@@ -54,8 +54,9 @@ namespace homething_menu_base {
 class MenuCommand : public EntityBase {
  public:
   void on_command() { this->on_command_callbacks_.call(); }
-  void add_on_command_callback(std::function<void()>&& callback) {
-    this->on_command_callbacks_.add(std::move(callback));
+  template <typename F>
+  void add_on_command_callback(F&& callback) {
+    this->on_command_callbacks_.add(std::forward<F>(callback));
   }
 
   std::string get_name() const { return name_; }
@@ -189,8 +190,9 @@ class HomeThingMenuScreen
   }
 #endif
 
-  void add_on_state_callback(std::function<void()>&& callback) {
-    this->callback_.add(std::move(callback));
+  template <typename F>
+  void add_on_state_callback(F&& callback) {
+    this->callback_.add(std::forward<F>(callback));
   }
   void menu_titles(std::vector<MenuTitleBase*>* menu_titles, bool show_name);
   bool select_menu(int index);

--- a/components/homeThingApp/homeThingApp.h
+++ b/components/homeThingApp/homeThingApp.h
@@ -42,7 +42,10 @@ class HomeThingApp : public homething_menu_base::HomeThingMenuHeaderSource,
   virtual void reset_menu() {}
   virtual void set_app_menu_index(int app_menu_index) {}
   virtual bool has_state_callback() { return false; }
-  virtual void add_on_state_callback(std::function<void()>&& callback) {}
+  template <typename F>
+  void add_on_state_callback(F&& callback) {
+    this->state_callback_.add(std::forward<F>(callback));
+  }
 
   // buttons
   virtual NavigationCoordination rotaryScrollClockwise(int rotary) {
@@ -87,6 +90,7 @@ class HomeThingApp : public homething_menu_base::HomeThingMenuHeaderSource,
   }
 
  protected:
+  CallbackManager<void()> state_callback_{};
   homething_menu_base::HomeThingMenuHeaderSource* header_source_{nullptr};
   display::Display* display_{nullptr};
   homething_display_state::HomeThingDisplayState* display_state_{nullptr};

--- a/components/homeThingAppBreakout/homeThingAppBreakout.h
+++ b/components/homeThingAppBreakout/homeThingAppBreakout.h
@@ -62,7 +62,6 @@ class HomeThingAppBreakout : public homething_menu_app::HomeThingApp {
 
   // state callback
   bool has_state_callback() { return false; }
-  void add_on_state_callback(std::function<void()>&& callback) {}
 
   // buttons
   homething_menu_app::NavigationCoordination rotaryScrollClockwise(int rotary);

--- a/components/homeThingAppCatToy/homeThingCatToyApp.h
+++ b/components/homeThingAppCatToy/homeThingCatToyApp.h
@@ -71,7 +71,6 @@ class HomeThingCatToyApp : public homething_menu_app::HomeThingApp {
 
   // state callback
   bool has_state_callback() { return false; }
-  void add_on_state_callback(std::function<void()>&& callback) {}
 
  private:
   const char* const TAG = "homething.app.cattoy";

--- a/components/homeThingAppNowPlaying/homeThingNowPlayingControl.cpp
+++ b/components/homeThingAppNowPlaying/homeThingNowPlayingControl.cpp
@@ -17,7 +17,7 @@ void HomeThingMenuNowPlayingControl::set_media_player_group(
            media_player_group_ == nullptr);
   media_player_group_ = media_player_group;
   media_player_group_->add_on_state_callback(
-      [this](media_player::MediaPlayerState) { this->callback_.call(); });
+      [this](media_player::MediaPlayerState) { this->state_callback_.call(); });
   header_source_ =
       new HomeThingMenuNowPlayingHeader(media_player_group, &menu_state_);
 }

--- a/components/homeThingAppNowPlaying/homeThingNowPlayingControl.h
+++ b/components/homeThingAppNowPlaying/homeThingNowPlayingControl.h
@@ -98,9 +98,6 @@ class HomeThingMenuNowPlayingControl : public homething_menu_app::HomeThingApp {
 
   // state callback
   bool has_state_callback() { return true; }
-  void add_on_state_callback(std::function<void()>&& callback) {
-    this->callback_.add(std::move(callback));
-  }
 
  protected:
   homeassistant_media_player::HomeAssistantMediaPlayerGroup*
@@ -112,7 +109,6 @@ class HomeThingMenuNowPlayingControl : public homething_menu_app::HomeThingApp {
 
  private:
   const char* const TAG = "homething.nowplaying.control";
-  CallbackManager<void()> callback_;
 
   // controls
   void select_media_player_feature(

--- a/components/homeThingAppSnake/homeThingAppSnake.h
+++ b/components/homeThingAppSnake/homeThingAppSnake.h
@@ -89,7 +89,6 @@ class HomeThingAppSnake : public homething_menu_app::HomeThingApp {
 
   // state callback
   bool has_state_callback() { return false; }
-  void add_on_state_callback(std::function<void()>&& callback) {}
 
  private:
   const char* const TAG = "homething.app.snake";

--- a/components/homeThingAppWeather/HomeThingAppWeather.h
+++ b/components/homeThingAppWeather/HomeThingAppWeather.h
@@ -70,7 +70,6 @@ class HomeThingAppWeather : public homething_menu_app::HomeThingApp {
 
   // state callback
   bool has_state_callback() { return false; }
-  void add_on_state_callback(std::function<void()>&& callback) {}
 
   // sensors
   void set_temperature_sensor(sensor::Sensor* temperature_sensor) {


### PR DESCRIPTION
Closes #152.

ESPHome 2026.4.0 replaced `std::function` with a lightweight `Callback` struct in `CallbackManager` (esphome/esphome#14853). Passing `std::function` still compiles but forces the heap-allocating path. This converts every callback registration point in this repo to the forwarding-template form, which is backward compatible with older ESPHome — no version guards needed.

## Straightforward conversions

- `homeThingMenuScreen.h` — `MenuCommand::add_on_command_callback`, `HomeThingMenuScreen::add_on_state_callback`
- `homeThingMenuBase.h` — `add_on_redraw_callback`
- `homeThingMenuDisplay.h` — `add_on_state_callback`
- `homeThingMenuBoot.h` — `add_on_state_callback`

## `HomeThingApp` needed restructuring

`HomeThingApp::add_on_state_callback` was `virtual`, and templates can't be virtual. Rather than leave a `std::function` sink in place, the `CallbackManager<void()>` moved up into the base class as a protected `state_callback_`, and registration became a non-virtual forwarding template. Virtual dispatch is gone from this path entirely.

Consequences:

- The four no-op overrides (Snake, Breakout, Weather, CatToy) were deleted. All four return `false` from `has_state_callback()`, and `homeThingMenuBase.cpp` gates registration on that, so nothing ever registered against them — behavior is unchanged.
- `HomeThingMenuNowPlayingControl` dropped its override and its private `callback_` in favour of the inherited `state_callback_`.

`has_state_callback()` stays virtual — it returns a plain `bool` and isn't part of the callback path.

No `std::function` remains anywhere under `components/`.

## Testing

`esphome compile` of `tdisplay-s3.yaml` (pointed at local `components/`, ESPHome 2026.6.4) builds clean — SUCCESS, zero errors. That config pulls in all five apps plus the menu screen/base/boot/display components, so every changed file is covered.